### PR TITLE
Fix bookmarks

### DIFF
--- a/src/patchAnchorElements.js
+++ b/src/patchAnchorElements.js
@@ -6,11 +6,14 @@ const BLOCK_NODE_NAME_PATTERN = /(P|H1|H2|H3|H4|H5|H6)/;
 
 export default function patchAnchorElements(doc: Document): void {
   Array.from(doc.querySelectorAll('a[id]')).forEach(patchAnchorElement);
+  Array.from(
+    doc.querySelectorAll('h1[id], h2[id], h3[id], h4[id], h5[id], h6[id]')
+  ).forEach(patchHeaderElements);
 }
 
 function patchAnchorElement(node: HTMLElement): void {
   const {id} = node;
-  if (id && node.childElementCount === 0) {
+  if (id && id.indexOf('t.') !== 0 && node.childElementCount === 0) {
     // This looks like a bookmark generated from Google Doc, will render
     // this as BookmarkNode.
     node.setAttribute(ATTRIBUTE_BOOKMARK_ID, id);
@@ -22,5 +25,18 @@ function patchAnchorElement(node: HTMLElement): void {
   // If this is next to a block element, make that block element the bookmark.
   if (BLOCK_NODE_NAME_PATTERN.test(nextNode.nodeName)) {
     nextNode.insertBefore(node, nextNode.firstChild);
+  }
+}
+
+function patchHeaderElements(node: HTMLElement): void {
+  const {id} = node;
+  console.log('id1', id)
+  if (id && id.indexOf('h.') === 0 && node.firstChild && node.firstChild.hasChildNodes()) {
+    console.log('id2', id)
+    // Heading tags have the id referenced directly on the element, so create
+    // a proper anchor tag and insert it heading tag
+    const anchorNode = document.createElement('a')
+    anchorNode.setAttribute(ATTRIBUTE_BOOKMARK_ID, id);
+    node.insertBefore(anchorNode, node.firstChild);
   }
 }


### PR DESCRIPTION
In this diff we fix two small bookmarking bugs.

### 1. Unexpected double bookmark
![screen shot 2019-01-11 at 11 18 49 am](https://user-images.githubusercontent.com/45044826/51054790-bd7cec00-1592-11e9-874e-943b93a1df79.png)

When converted into a platform doc, we consistently generated 2 rogue bookmark links

**Solution**
Previously we assumed any element with an attribute `id=...` would should be converted into a bookmark. Based off of our sample conversions, this isn't true for tags that are directly before table elements, like this example


```HTML
    <p class="c1 c7"><span class="c3"></span></p>
    <a id="t.3c6b9c1d29f539faa9f4fba1f19461b4404f76c7"></a>
    <a id="t.0"></a>
    <table class="c14">
       ...
    </table>
```
The tags like `<a id="t.0"></a>` feel safe to remove because no other portion of the full html actually has an `href` attribute that links to them

### 3. Bookmarks don't work for headings

More specifically, the heading in the document wasn't styled with the bookmark node spec

That's because previously we were only sanitizing the html of a tags:

```HTML
Array.from(doc.querySelectorAll('a[id]')).forEach(patchAnchorElement);
```
But there is actually HTML that exists like the following, which would not be caught by the line above:

```HTML
    <h1 class="c20" id="h.4sx4uc42hk7">
      <span class="c5"></span>
    </h1>
```

So in this diff I make sure we convert this to 
```HTML
    <h1 class="c20" id="h.4sx4uc42hk7">
      <a bookmark-id="h.4sx4uc42hk7"></a>
      <span class="c5"></span>
    </h1>
```

That way it could be picked up by the `parseDOM` method in the `BookMarkNodeSpec`.
Alternatively, I could have just changed the `parseDOM` method to also find tags like `<h1>, <h2>, ...`
but that felt weird because it would clash with the `HeadingNodeSpec`
