### PR TITLE
fix border color

### DIFF
--- a/src/TableNodesSpecs.js
+++ b/src/TableNodesSpecs.js
@@ -4,6 +4,8 @@ import {tableNodes} from 'prosemirror-tables';
 
 import toHexColor from './ui/toHexColor';
 
+const NO_VISIBLE_BORDER_WIDTH = new Set(['0pt', '0px'])
+
 // https://github.com/ProseMirror/prosemirror-tables/blob/master/demo.js
 const TableNodesSpecs = tableNodes({
   tableGroup: 'block',
@@ -12,7 +14,12 @@ const TableNodesSpecs = tableNodes({
     borderColor: {
       default: null,
       getFromDOM(dom) {
-        const {borderColor} = dom.style;
+        const {borderColor, borderWidth} = dom.style;
+
+        if (NO_VISIBLE_BORDER_WIDTH.has(borderWidth)) {
+          return 'transparent';
+        }
+
         return (borderColor && toHexColor(borderColor)) || null;
       },
       setDOMAttr(value, attrs) {


### PR DESCRIPTION
This diff supports transparent borders, which google implements as block borders with width of `0pt`. I've also added a check for `0px` just for robustness, but it might not be necessary (no real way to check)