### PR TITLE
prevent center popover from floating offscreen left

### DIFF
--- a/dist/ui/PopUpPosition.js
+++ b/dist/ui/PopUpPosition.js
@@ -40,7 +40,7 @@ function atAnchorBottom(anchorRect, bodyRect) {
 function atAnchorBottomCenter(anchorRect, bodyRect) {
   var rect = { x: 0, y: 0, w: 0, h: 0 };
   if (anchorRect && bodyRect) {
-    rect.x = anchorRect.x - (bodyRect.w - anchorRect.w) / 2;
+    rect.x = Math.max(anchorRect.x - (bodyRect.w - anchorRect.w) / 2, 10);
     rect.y = anchorRect.y + anchorRect.h;
   }
 

--- a/dist/ui/PopUpPosition.js.flow
+++ b/dist/ui/PopUpPosition.js.flow
@@ -32,7 +32,10 @@ export function atAnchorBottom(anchorRect: ?Rect, bodyRect: ?Rect): Rect {
 export function atAnchorBottomCenter(anchorRect: ?Rect, bodyRect: ?Rect): Rect {
   const rect = {x: 0, y: 0, w: 0, h: 0};
   if (anchorRect && bodyRect) {
-    rect.x = anchorRect.x - (bodyRect.w - anchorRect.w) / 2;
+    rect.x = Math.max(
+      anchorRect.x - (bodyRect.w - anchorRect.w) / 2,
+      10,
+    );
     rect.y = anchorRect.y + anchorRect.h;
   }
 

--- a/src/ui/PopUpPosition.js
+++ b/src/ui/PopUpPosition.js
@@ -32,7 +32,10 @@ export function atAnchorBottom(anchorRect: ?Rect, bodyRect: ?Rect): Rect {
 export function atAnchorBottomCenter(anchorRect: ?Rect, bodyRect: ?Rect): Rect {
   const rect = {x: 0, y: 0, w: 0, h: 0};
   if (anchorRect && bodyRect) {
-    rect.x = anchorRect.x - (bodyRect.w - anchorRect.w) / 2;
+    rect.x = Math.max(
+      anchorRect.x - (bodyRect.w - anchorRect.w) / 2,
+      10,
+    );
     rect.y = anchorRect.y + anchorRect.h;
   }
 


### PR DESCRIPTION
I created some examples to test by messing with the toolbar config (those changes aren't in this diff)

showing bottom-centered menu continuing to operate as normal
![screen shot 2019-02-25 at 11 34 32 am](https://user-images.githubusercontent.com/45044826/53363757-2675b480-38f2-11e9-9da0-8eb460a10c42.png)

Showing non-overflow left bottom-centered menu:
![screen shot 2019-02-25 at 11 32 51 am](https://user-images.githubusercontent.com/45044826/53363727-1958c580-38f2-11e9-9fbd-1d7b84851915.png)


@hedgerwang , if you approve of this I'll add a commit on top that rebuilds `/dist` and then merge

