### PR TITLE
Popoverpos

### DIFF
--- a/dist/ui/PopUpPosition.js
+++ b/dist/ui/PopUpPosition.js
@@ -5,6 +5,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.atAnchorBottom = atAnchorBottom;
 exports.atAnchorBottomCenter = atAnchorBottomCenter;
+exports.atAnchorBottomLeft = atAnchorBottomLeft;
 exports.atAnchorRight = atAnchorRight;
 exports.atViewportCenter = atViewportCenter;
 exports.atAnchorTopRight = atAnchorTopRight;
@@ -41,6 +42,20 @@ function atAnchorBottomCenter(anchorRect, bodyRect) {
   var rect = { x: 0, y: 0, w: 0, h: 0 };
   if (anchorRect && bodyRect) {
     rect.x = Math.max(anchorRect.x - (bodyRect.w - anchorRect.w) / 2, 10);
+    rect.y = anchorRect.y + anchorRect.h;
+  }
+
+  if (!anchorRect || (0, _rects.isCollapsed)(anchorRect)) {
+    rect.x = -10000;
+  }
+
+  return rect;
+}
+
+function atAnchorBottomLeft(anchorRect, bodyRect) {
+  var rect = { x: 0, y: 0, w: 0, h: 0 };
+  if (anchorRect && bodyRect) {
+    rect.x = anchorRect.x;
     rect.y = anchorRect.y + anchorRect.h;
   }
 

--- a/dist/ui/PopUpPosition.js.flow
+++ b/dist/ui/PopUpPosition.js.flow
@@ -46,6 +46,20 @@ export function atAnchorBottomCenter(anchorRect: ?Rect, bodyRect: ?Rect): Rect {
   return rect;
 }
 
+export function atAnchorBottomLeft(anchorRect: ?Rect, bodyRect: ?Rect): Rect {
+  const rect = {x: 0, y: 0, w: 0, h: 0};
+  if (anchorRect && bodyRect) {
+    rect.x = anchorRect.x;
+    rect.y = anchorRect.y + anchorRect.h;
+  }
+
+  if (!anchorRect || isCollapsed(anchorRect)) {
+    rect.x = -10000;
+  }
+
+  return rect;
+}
+
 export function atAnchorRight(anchorRect: ?Rect, bodyRect: ?Rect): Rect {
   const rect = {x: 0, y: 0, w: 0, h: 0};
   if (anchorRect && bodyRect) {

--- a/src/ui/PopUpPosition.js
+++ b/src/ui/PopUpPosition.js
@@ -46,6 +46,20 @@ export function atAnchorBottomCenter(anchorRect: ?Rect, bodyRect: ?Rect): Rect {
   return rect;
 }
 
+export function atAnchorBottomLeft(anchorRect: ?Rect, bodyRect: ?Rect): Rect {
+  const rect = {x: 0, y: 0, w: 0, h: 0};
+  if (anchorRect && bodyRect) {
+    rect.x = anchorRect.x;
+    rect.y = anchorRect.y + anchorRect.h;
+  }
+
+  if (!anchorRect || isCollapsed(anchorRect)) {
+    rect.x = -10000;
+  }
+
+  return rect;
+}
+
 export function atAnchorRight(anchorRect: ?Rect, bodyRect: ?Rect): Rect {
   const rect = {x: 0, y: 0, w: 0, h: 0};
   if (anchorRect && bodyRect) {


### PR DESCRIPTION
Need to add this positioning to support something in traject

Test Plan:
Tried this new positioning in the editor, see its left aligned
<img width="279" alt="screen shot 2019-03-01 at 12 33 51 pm" src="https://user-images.githubusercontent.com/45044826/53667212-301a5780-3c25-11e9-821b-299c81b7c292.png">
