### PR TITLE
preserve original attributes on text align command

### DIFF
--- a/src/TextAlignCommand.js
+++ b/src/TextAlignCommand.js
@@ -54,7 +54,7 @@ export function setTextAlign(
 
   tasks.forEach(job => {
     const {node, pos, nodeType} = job;
-    let attrs;
+    let {attrs} = node;
     if (alignment) {
       attrs = {
         ...attrs,


### PR DESCRIPTION
Current bug: On alignment, nodes revert back to default behaviour

GIF
![error in align](https://user-images.githubusercontent.com/45044826/53676261-ae422280-3c54-11e9-9fdb-3e5266536b63.gif)

That was because we weren't merging the orignal node attributes with the new `align` attribute