### PR TITLE
[fix] Swap 10 and 11 in font size menu.

### DIFF
--- a/dist/ui/FontSizeCommandMenuButton.js
+++ b/dist/ui/FontSizeCommandMenuButton.js
@@ -48,7 +48,7 @@ var _findActiveFontSize2 = _interopRequireDefault(_findActiveFontSize);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var FONT_PT_SIZES = [8, 9, 11, 10, 12, 14, 18, 24, 30, 36, 48, 60, 72, 90];
+var FONT_PT_SIZES = [8, 9, 10, 11, 12, 14, 18, 24, 30, 36, 48, 60, 72, 90];
 
 var FONT_PT_SIZE_COMMANDS = FONT_PT_SIZES.reduce(function (memo, size) {
   memo[' ' + size + ' '] = new _FontSizeCommand2.default(size);

--- a/dist/ui/FontSizeCommandMenuButton.js.flow
+++ b/dist/ui/FontSizeCommandMenuButton.js.flow
@@ -9,7 +9,7 @@ import FontSizeCommand from '../FontSizeCommand';
 import CommandMenuButton from './CommandMenuButton';
 import findActiveFontSize from './findActiveFontSize';
 
-const FONT_PT_SIZES = [8, 9, 11, 10, 12, 14, 18, 24, 30, 36, 48, 60, 72, 90];
+const FONT_PT_SIZES = [8, 9, 10, 11, 12, 14, 18, 24, 30, 36, 48, 60, 72, 90];
 
 const FONT_PT_SIZE_COMMANDS = FONT_PT_SIZES.reduce((memo, size) => {
   memo[` ${size} `] = new FontSizeCommand(size);

--- a/src/ui/FontSizeCommandMenuButton.js
+++ b/src/ui/FontSizeCommandMenuButton.js
@@ -9,7 +9,7 @@ import FontSizeCommand from '../FontSizeCommand';
 import CommandMenuButton from './CommandMenuButton';
 import findActiveFontSize from './findActiveFontSize';
 
-const FONT_PT_SIZES = [8, 9, 11, 10, 12, 14, 18, 24, 30, 36, 48, 60, 72, 90];
+const FONT_PT_SIZES = [8, 9, 10, 11, 12, 14, 18, 24, 30, 36, 48, 60, 72, 90];
 
 const FONT_PT_SIZE_COMMANDS = FONT_PT_SIZES.reduce((memo, size) => {
   memo[` ${size} `] = new FontSizeCommand(size);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1837091/53755236-df943b80-3e6a-11e9-9bb3-1e43b60ce799.png)

Note: I'll fix up the submenu alignment in a follow-up diff after we update our positioning options.