### PR TITLE
[fix] Don't show tooltips in print mode

### DIFF
--- a/dist/TextAlignCommand.js
+++ b/dist/TextAlignCommand.js
@@ -90,8 +90,8 @@ function setTextAlign(tr, schema, alignment) {
     var node = job.node,
         pos = job.pos,
         nodeType = job.nodeType;
+    var attrs = node.attrs;
 
-    var attrs = void 0;
     if (alignment) {
       attrs = (0, _extends3.default)({}, attrs, {
         align: alignment

--- a/dist/TextAlignCommand.js.flow
+++ b/dist/TextAlignCommand.js.flow
@@ -54,7 +54,7 @@ export function setTextAlign(
 
   tasks.forEach(job => {
     const {node, pos, nodeType} = job;
-    let attrs;
+    let {attrs} = node;
     if (alignment) {
       attrs = {
         ...attrs,

--- a/dist/ui/czi-tooltip-surface.css
+++ b/dist/ui/czi-tooltip-surface.css
@@ -20,6 +20,12 @@
   user-select: none;
 }
 
+@media only print {
+  .czi-tooltip-view {
+    display: none;
+  }
+}
+
 .czi-tooltip-view.czi-animation-fade-in {
   animation-duration: 250ms;
   animation-delay: 150ms;

--- a/src/ui/czi-tooltip-surface.css
+++ b/src/ui/czi-tooltip-surface.css
@@ -20,6 +20,12 @@
   user-select: none;
 }
 
+@media only print {
+  .czi-tooltip-view {
+    display: none;
+  }
+}
+
 .czi-tooltip-view.czi-animation-fade-in {
   animation-duration: 250ms;
   animation-delay: 150ms;


### PR DESCRIPTION
Before: (shows "Left Align" at top right)
![screen shot 2019-03-04 at 11 39 47 am](https://user-images.githubusercontent.com/1837091/53758259-6567b500-3e72-11e9-8410-60c7e35f273b.png)

After:
![screen shot 2019-03-04 at 11 40 03 am](https://user-images.githubusercontent.com/1837091/53758264-6862a580-3e72-11e9-9c4f-83cb0e7a2011.png)
