### PR TITLE
Clean up at anchor bottom

### DIFF
--- a/dist/TextAlignCommand.js
+++ b/dist/TextAlignCommand.js
@@ -90,8 +90,8 @@ function setTextAlign(tr, schema, alignment) {
     var node = job.node,
         pos = job.pos,
         nodeType = job.nodeType;
+    var attrs = node.attrs;
 
-    var attrs = void 0;
     if (alignment) {
       attrs = (0, _extends3.default)({}, attrs, {
         align: alignment

--- a/dist/TextAlignCommand.js.flow
+++ b/dist/TextAlignCommand.js.flow
@@ -54,7 +54,7 @@ export function setTextAlign(
 
   tasks.forEach(job => {
     const {node, pos, nodeType} = job;
-    let attrs;
+    let {attrs} = node;
     if (alignment) {
       attrs = {
         ...attrs,

--- a/dist/ui/PopUp.js
+++ b/dist/ui/PopUp.js
@@ -107,7 +107,7 @@ var PopUp = function (_React$PureComponent) {
         body: document.getElementById(_this._id),
         close: close,
         modal: modal === true,
-        position: position || (modal ? _PopUpPosition.atViewportCenter : _PopUpPosition.atAnchorBottom)
+        position: position || (modal ? _PopUpPosition.atViewportCenter : _PopUpPosition.atAnchorBottomLeft)
       };
     }, _temp), (0, _possibleConstructorReturn3.default)(_this, _ret);
   }

--- a/dist/ui/PopUp.js.flow
+++ b/dist/ui/PopUp.js.flow
@@ -3,7 +3,7 @@
 import PopUpManager from './PopUpManager';
 import React from 'react';
 import uuid from './uuid';
-import {atAnchorBottom, atViewportCenter} from './PopUpPosition';
+import {atAnchorBottomLeft, atViewportCenter} from './PopUpPosition';
 
 import type {Rect} from './rects';
 import type {PopUpDetails} from './PopUpManager';
@@ -72,7 +72,7 @@ class PopUp extends React.PureComponent {
       body: document.getElementById(this._id),
       close,
       modal: modal === true,
-      position: position || (modal ? atViewportCenter : atAnchorBottom),
+      position: position || (modal ? atViewportCenter : atAnchorBottomLeft),
     };
   };
 }

--- a/dist/ui/PopUpPosition.js
+++ b/dist/ui/PopUpPosition.js
@@ -17,7 +17,7 @@ var babelPluginFlowReactPropTypes_proptype_Rect = require('./rects').babelPlugin
 function atAnchorBottom(anchorRect, bodyRect) {
   var rect = { x: 0, y: 0, w: 0, h: 0 };
   if (anchorRect && bodyRect) {
-    rect.x = anchorRect.x + anchorRect.w / 2;
+    rect.x = anchorRect.x;
     rect.y = anchorRect.y + anchorRect.h;
 
     var viewportWidth = window.innerWidth;

--- a/dist/ui/PopUpPosition.js
+++ b/dist/ui/PopUpPosition.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.atAnchorBottom = atAnchorBottom;
+exports.atAnchorBottomLeft = atAnchorBottomLeft;
 exports.atAnchorBottomCenter = atAnchorBottomCenter;
 exports.atAnchorRight = atAnchorRight;
 exports.atViewportCenter = atViewportCenter;
@@ -14,7 +14,7 @@ var _rects = require('./rects');
 
 var babelPluginFlowReactPropTypes_proptype_Rect = require('./rects').babelPluginFlowReactPropTypes_proptype_Rect || require('prop-types').any;
 
-function atAnchorBottom(anchorRect, bodyRect) {
+function atAnchorBottomLeft(anchorRect, bodyRect) {
   var rect = { x: 0, y: 0, w: 0, h: 0 };
   if (anchorRect && bodyRect) {
     rect.x = anchorRect.x;

--- a/dist/ui/PopUpPosition.js.flow
+++ b/dist/ui/PopUpPosition.js.flow
@@ -6,7 +6,7 @@ import type {Rect} from './rects';
 
 export type PositionHandler = (anchorRect: ?Rect, bodyRect: ?Rect) => Rect;
 
-export function atAnchorBottom(anchorRect: ?Rect, bodyRect: ?Rect): Rect {
+export function atAnchorBottomLeft(anchorRect: ?Rect, bodyRect: ?Rect): Rect {
   const rect = {x: 0, y: 0, w: 0, h: 0};
   if (anchorRect && bodyRect) {
     rect.x = anchorRect.x;

--- a/dist/ui/PopUpPosition.js.flow
+++ b/dist/ui/PopUpPosition.js.flow
@@ -9,7 +9,7 @@ export type PositionHandler = (anchorRect: ?Rect, bodyRect: ?Rect) => Rect;
 export function atAnchorBottom(anchorRect: ?Rect, bodyRect: ?Rect): Rect {
   const rect = {x: 0, y: 0, w: 0, h: 0};
   if (anchorRect && bodyRect) {
-    rect.x = anchorRect.x + anchorRect.w / 2;
+    rect.x = anchorRect.x;
     rect.y = anchorRect.y + anchorRect.h;
 
     const viewportWidth = window.innerWidth;

--- a/dist/ui/TooltipSurface.js
+++ b/dist/ui/TooltipSurface.js
@@ -36,6 +36,8 @@ var _createPopUp = require('./createPopUp');
 
 var _createPopUp2 = _interopRequireDefault(_createPopUp);
 
+var _PopUpPosition = require('./PopUpPosition');
+
 var _uuid = require('./uuid');
 
 var _uuid2 = _interopRequireDefault(_uuid);
@@ -85,7 +87,8 @@ var TooltipSurface = function (_React$PureComponent2) {
 
         _this2._popUp = (0, _createPopUp2.default)(TooltipView, { tooltip: _tooltip }, {
           anchor: document.getElementById(_this2._id),
-          onClose: _this2._onClose
+          onClose: _this2._onClose,
+          position: _PopUpPosition.atAnchorBottomCenter
         });
       }
     }, _this2._onMouseLeave = function () {

--- a/dist/ui/TooltipSurface.js.flow
+++ b/dist/ui/TooltipSurface.js.flow
@@ -5,6 +5,7 @@ import './czi-animations.css';
 
 import React from 'react';
 import createPopUp from './createPopUp';
+import { atAnchorBottomCenter } from './PopUpPosition';
 import uuid from './uuid';
 
 class TooltipView extends React.PureComponent<any, any, any> {
@@ -55,6 +56,7 @@ class TooltipSurface extends React.PureComponent<any, any, any> {
       this._popUp = createPopUp(TooltipView, {tooltip}, {
         anchor: document.getElementById(this._id),
         onClose: this._onClose,
+        position: atAnchorBottomCenter,
       });
     }
   };

--- a/dist/ui/czi-tooltip-surface.css
+++ b/dist/ui/czi-tooltip-surface.css
@@ -12,7 +12,7 @@
   color: #fff;
   font-family: var(--czi-font-family);
   font-size: var(--czi-font-size);
-  margin: 20px 0 0 -50px;
+  margin: 20px 0 0 -40px;
   min-width: 100px;
   padding: 6px 8px;
   pointer-events: none;
@@ -29,7 +29,7 @@
   background-color: #393939;
   content: '';
   height: 8px;
-  left: -4px;
+  left: 8px;
   position: absolute;
   top: -4px;
   transform: rotate(45deg);

--- a/dist/ui/czi-tooltip-surface.css
+++ b/dist/ui/czi-tooltip-surface.css
@@ -12,7 +12,7 @@
   color: #fff;
   font-family: var(--czi-font-family);
   font-size: var(--czi-font-size);
-  margin: 20px 0 0 -40px;
+  margin: 20px 0 0 0;
   min-width: 100px;
   padding: 6px 8px;
   pointer-events: none;
@@ -29,7 +29,7 @@
   background-color: #393939;
   content: '';
   height: 8px;
-  left: 8px;
+  left: 46px;
   position: absolute;
   top: -4px;
   transform: rotate(45deg);

--- a/src/ui/PopUp.js
+++ b/src/ui/PopUp.js
@@ -3,7 +3,7 @@
 import PopUpManager from './PopUpManager';
 import React from 'react';
 import uuid from './uuid';
-import {atAnchorBottom, atViewportCenter} from './PopUpPosition';
+import {atAnchorBottomLeft, atViewportCenter} from './PopUpPosition';
 
 import type {Rect} from './rects';
 import type {PopUpDetails} from './PopUpManager';
@@ -72,7 +72,7 @@ class PopUp extends React.PureComponent {
       body: document.getElementById(this._id),
       close,
       modal: modal === true,
-      position: position || (modal ? atViewportCenter : atAnchorBottom),
+      position: position || (modal ? atViewportCenter : atAnchorBottomLeft),
     };
   };
 }

--- a/src/ui/PopUpPosition.js
+++ b/src/ui/PopUpPosition.js
@@ -6,7 +6,7 @@ import type {Rect} from './rects';
 
 export type PositionHandler = (anchorRect: ?Rect, bodyRect: ?Rect) => Rect;
 
-export function atAnchorBottom(anchorRect: ?Rect, bodyRect: ?Rect): Rect {
+export function atAnchorBottomLeft(anchorRect: ?Rect, bodyRect: ?Rect): Rect {
   const rect = {x: 0, y: 0, w: 0, h: 0};
   if (anchorRect && bodyRect) {
     rect.x = anchorRect.x;

--- a/src/ui/PopUpPosition.js
+++ b/src/ui/PopUpPosition.js
@@ -9,7 +9,7 @@ export type PositionHandler = (anchorRect: ?Rect, bodyRect: ?Rect) => Rect;
 export function atAnchorBottom(anchorRect: ?Rect, bodyRect: ?Rect): Rect {
   const rect = {x: 0, y: 0, w: 0, h: 0};
   if (anchorRect && bodyRect) {
-    rect.x = anchorRect.x + anchorRect.w / 2;
+    rect.x = anchorRect.x;
     rect.y = anchorRect.y + anchorRect.h;
 
     const viewportWidth = window.innerWidth;

--- a/src/ui/TooltipSurface.js
+++ b/src/ui/TooltipSurface.js
@@ -5,6 +5,7 @@ import './czi-animations.css';
 
 import React from 'react';
 import createPopUp from './createPopUp';
+import { atAnchorBottomCenter } from './PopUpPosition';
 import uuid from './uuid';
 
 class TooltipView extends React.PureComponent<any, any, any> {
@@ -55,6 +56,7 @@ class TooltipSurface extends React.PureComponent<any, any, any> {
       this._popUp = createPopUp(TooltipView, {tooltip}, {
         anchor: document.getElementById(this._id),
         onClose: this._onClose,
+        position: atAnchorBottomCenter,
       });
     }
   };

--- a/src/ui/czi-tooltip-surface.css
+++ b/src/ui/czi-tooltip-surface.css
@@ -12,7 +12,7 @@
   color: #fff;
   font-family: var(--czi-font-family);
   font-size: var(--czi-font-size);
-  margin: 20px 0 0 -50px;
+  margin: 20px 0 0 -40px;
   min-width: 100px;
   padding: 6px 8px;
   pointer-events: none;
@@ -29,7 +29,7 @@
   background-color: #393939;
   content: '';
   height: 8px;
-  left: -4px;
+  left: 8px;
   position: absolute;
   top: -4px;
   transform: rotate(45deg);

--- a/src/ui/czi-tooltip-surface.css
+++ b/src/ui/czi-tooltip-surface.css
@@ -12,7 +12,7 @@
   color: #fff;
   font-family: var(--czi-font-family);
   font-size: var(--czi-font-size);
-  margin: 20px 0 0 -40px;
+  margin: 20px 0 0 0;
   min-width: 100px;
   padding: 6px 8px;
   pointer-events: none;
@@ -29,7 +29,7 @@
   background-color: #393939;
   content: '';
   height: 8px;
-  left: 8px;
+  left: 46px;
   position: absolute;
   top: -4px;
   transform: rotate(45deg);


### PR DESCRIPTION
As discussed offline, this reverts the changes to `atAnchorBottom` and renames it to `atAnchorBottomLeft` for clarity. It switches the tooltip to using `atAnchorBottomCenter`.

![screen shot 2019-03-04 at 3 37 37 pm](https://user-images.githubusercontent.com/1837091/53770468-06b33300-3e94-11e9-9c8b-3d43d4d20580.png)
![screen shot 2019-03-04 at 3 37 48 pm](https://user-images.githubusercontent.com/1837091/53770470-06b33300-3e94-11e9-8b9e-8afb6dc8690a.png)
![screen shot 2019-03-04 at 3 37 52 pm](https://user-images.githubusercontent.com/1837091/53770471-06b33300-3e94-11e9-8eda-e213ee89bd92.png)
![screen shot 2019-03-04 at 3 37 59 pm](https://user-images.githubusercontent.com/1837091/53770472-06b33300-3e94-11e9-9a2a-00d8cd1ee38c.png)
![screen shot 2019-03-04 at 3 38 03 pm](https://user-images.githubusercontent.com/1837091/53770473-06b33300-3e94-11e9-8b0d-dca86c12d1e4.png)
