### PR TITLE
[fix] Update empty check since text node can be an atom

### DIFF
--- a/dist/isEditorStateEmpty.js
+++ b/dist/isEditorStateEmpty.js
@@ -21,12 +21,12 @@ function isEditorStateEmpty(editorState) {
     doc.nodesBetween(0, doc.nodeSize - 2, function (node, ii) {
       if (isEmpty) {
         var nodeType = node.type;
-        if (nodeType.isAtom) {
-          // e.g. Image, Video...etc.
-          isEmpty = false;
-        } else if (nodeType.isText) {
+        if (nodeType.isText) {
           var _text = doc.textContent;
           isEmpty = !_text || _text === ' ' || _text === ZERO_WIDTH_SPACE_CHAR;
+        } else if (nodeType.isAtom) {
+          // e.g. Image, Video...etc.
+          isEmpty = false;
         }
       }
       return isEmpty;

--- a/dist/isEditorStateEmpty.js.flow
+++ b/dist/isEditorStateEmpty.js.flow
@@ -15,12 +15,12 @@ export default function isEditorStateEmpty(editorState: EditorState): boolean {
     doc.nodesBetween(0, doc.nodeSize - 2, (node, ii) => {
       if (isEmpty) {
         const nodeType = node.type;
-        if (nodeType.isAtom) {
-          // e.g. Image, Video...etc.
-          isEmpty = false;
-        } else if (nodeType.isText) {
+        if (nodeType.isText) {
           const text = doc.textContent;
           isEmpty = !text || text === ' ' || text === ZERO_WIDTH_SPACE_CHAR;
+        } else if (nodeType.isAtom) {
+          // e.g. Image, Video...etc.
+          isEmpty = false;
         }
       }
       return isEmpty;

--- a/src/isEditorStateEmpty.js
+++ b/src/isEditorStateEmpty.js
@@ -15,12 +15,12 @@ export default function isEditorStateEmpty(editorState: EditorState): boolean {
     doc.nodesBetween(0, doc.nodeSize - 2, (node, ii) => {
       if (isEmpty) {
         const nodeType = node.type;
-        if (nodeType.isAtom) {
-          // e.g. Image, Video...etc.
-          isEmpty = false;
-        } else if (nodeType.isText) {
+        if (nodeType.isText) {
           const text = doc.textContent;
           isEmpty = !text || text === ' ' || text === ZERO_WIDTH_SPACE_CHAR;
+        } else if (nodeType.isAtom) {
+          // e.g. Image, Video...etc.
+          isEmpty = false;
         }
       }
       return isEmpty;


### PR DESCRIPTION
Placeholder wasn't showing for " " content (the default) since the text node was passing the `isAtom` case.

Fix:
![image](https://user-images.githubusercontent.com/1837091/53984555-6e54c280-40ce-11e9-95ff-24ef07ddd4b1.png)
