### PR TITLE
Take in function for transforming pasted HTML

### DIFF
--- a/dist/ui/Editor.js
+++ b/dist/ui/Editor.js
@@ -138,7 +138,8 @@ if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginF
     nodeViews: require('prop-types').shape({}),
     placeholder: require('prop-types').oneOfType([require('prop-types').string, require('prop-types').any]),
     readOnly: require('prop-types').bool,
-    runtime: babelPluginFlowReactPropTypes_proptype_EditorRuntime
+    runtime: babelPluginFlowReactPropTypes_proptype_EditorRuntime,
+    transformPastedHTML: require('prop-types').func
   })
 });
 
@@ -238,7 +239,8 @@ var Editor = function (_React$PureComponent) {
           placeholder = _props.placeholder,
           disabled = _props.disabled,
           dispatchTransaction = _props.dispatchTransaction,
-          nodeViews = _props.nodeViews;
+          nodeViews = _props.nodeViews,
+          transformPastedHTML = _props.transformPastedHTML;
 
 
       var editorNode = document.getElementById(this._id);
@@ -264,7 +266,7 @@ var Editor = function (_React$PureComponent) {
           editable: this._isEditable,
           nodeViews: boundNodeViews,
           state: editorState || EDITOR_EMPTY_STATE,
-          transformPastedHTML: _normalizeHTML2.default,
+          transformPastedHTML: transformPastedHTML,
           handleDOMEvents: handleDOMEvents
         });
 
@@ -347,4 +349,7 @@ var Editor = function (_React$PureComponent) {
 }(_react2.default.PureComponent);
 
 Editor.EDITOR_EMPTY_STATE = EDITOR_EMPTY_STATE;
+Editor.defautProps = {
+  transformPastedHTML: _normalizeHTML2.default
+};
 exports.default = Editor;

--- a/dist/ui/Editor.js.flow
+++ b/dist/ui/Editor.js.flow
@@ -44,6 +44,7 @@ export type EditorProps = {
   placeholder?: ?(string | React.Element<any>),
   readOnly?: ?boolean,
   runtime?: ?EditorRuntime,
+  transformPastedHTML?: (html: string) => string,
 };
 
 const AUTO_FOCUS_DELAY = 350;
@@ -111,11 +112,16 @@ class Editor extends React.PureComponent<any, any, any> {
     isPrinting: false,
   };
 
+  static defautProps = {
+    transformPastedHTML: normalizeHTML,
+  }
+
   componentDidMount(): void {
     const {
       onReady, editorState, readOnly,
       runtime, placeholder, disabled,
       dispatchTransaction, nodeViews,
+      transformPastedHTML,
     } = this.props;
 
     const editorNode = document.getElementById(this._id);
@@ -144,7 +150,7 @@ class Editor extends React.PureComponent<any, any, any> {
         editable: this._isEditable,
         nodeViews: boundNodeViews,
         state: editorState || EDITOR_EMPTY_STATE,
-        transformPastedHTML: normalizeHTML,
+        transformPastedHTML,
         handleDOMEvents,
       });
 

--- a/dist/ui/Editor.js.flow
+++ b/dist/ui/Editor.js.flow
@@ -114,7 +114,7 @@ class Editor extends React.PureComponent<any, any, any> {
 
   static defautProps = {
     transformPastedHTML: normalizeHTML,
-  }
+  };
 
   componentDidMount(): void {
     const {

--- a/src/ui/Editor.js
+++ b/src/ui/Editor.js
@@ -44,6 +44,7 @@ export type EditorProps = {
   placeholder?: ?(string | React.Element<any>),
   readOnly?: ?boolean,
   runtime?: ?EditorRuntime,
+  transformPastedHTML?: (html: string) => string,
 };
 
 const AUTO_FOCUS_DELAY = 350;
@@ -111,11 +112,16 @@ class Editor extends React.PureComponent<any, any, any> {
     isPrinting: false,
   };
 
+  static defautProps = {
+    transformPastedHTML: normalizeHTML,
+  }
+
   componentDidMount(): void {
     const {
       onReady, editorState, readOnly,
       runtime, placeholder, disabled,
       dispatchTransaction, nodeViews,
+      transformPastedHTML,
     } = this.props;
 
     const editorNode = document.getElementById(this._id);
@@ -144,7 +150,7 @@ class Editor extends React.PureComponent<any, any, any> {
         editable: this._isEditable,
         nodeViews: boundNodeViews,
         state: editorState || EDITOR_EMPTY_STATE,
-        transformPastedHTML: normalizeHTML,
+        transformPastedHTML,
         handleDOMEvents,
       });
 

--- a/src/ui/Editor.js
+++ b/src/ui/Editor.js
@@ -114,7 +114,7 @@ class Editor extends React.PureComponent<any, any, any> {
 
   static defautProps = {
     transformPastedHTML: normalizeHTML,
-  }
+  };
 
   componentDidMount(): void {
     const {


### PR DESCRIPTION
This will be used for custom transformations upon paste, such as removing marks from comments that only exist in a different doc.