### PR TITLE
Round font sizes to nearest valid font size.

### DIFF
--- a/dist/FontSizeMarkSpec.js
+++ b/dist/FontSizeMarkSpec.js
@@ -8,10 +8,6 @@ var _prosemirrorModel = require('prosemirror-model');
 
 var _convertToCSSPTValue = require('./convertToCSSPTValue');
 
-var _convertToCSSPTValue2 = _interopRequireDefault(_convertToCSSPTValue);
-
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 var babelPluginFlowReactPropTypes_proptype_MarkSpec = require('./Types').babelPluginFlowReactPropTypes_proptype_MarkSpec || require('prop-types').any;
 
 var FontSizeMarkSpec = {
@@ -38,7 +34,7 @@ function getAttrs(fontSize) {
     return attrs;
   }
 
-  var ptValue = (0, _convertToCSSPTValue2.default)(fontSize);
+  var ptValue = (0, _convertToCSSPTValue.toClosestFontPtSize)(fontSize);
   if (!ptValue) {
     return attrs;
   }

--- a/dist/FontSizeMarkSpec.js.flow
+++ b/dist/FontSizeMarkSpec.js.flow
@@ -2,7 +2,7 @@
 
 import {Node} from 'prosemirror-model';
 
-import convertToCSSPTValue from './convertToCSSPTValue';
+import {toClosestFontPtSize} from './convertToCSSPTValue';
 
 import type {MarkSpec} from './Types';
 
@@ -31,7 +31,7 @@ function getAttrs(fontSize: string): Object {
     return attrs;
   }
 
-  const ptValue = convertToCSSPTValue(fontSize);
+  const ptValue = toClosestFontPtSize(fontSize);
   if (!ptValue) {
     return attrs;
   }

--- a/dist/convertToCSSPTValue.js
+++ b/dist/convertToCSSPTValue.js
@@ -3,7 +3,12 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.PT_TO_PX_RATIO = exports.PX_TO_PT_RATIO = undefined;
 exports.default = convertToCSSPTValue;
+exports.toClosestFontPtSize = toClosestFontPtSize;
+
+var _FontSizeCommandMenuButton = require('./ui/FontSizeCommandMenuButton');
+
 var SIZE_PATTERN = /([\d\.]+)(px|pt)/i;
 
 var PX_TO_PT_RATIO = exports.PX_TO_PT_RATIO = 0.7518796992481203; // 1 / 1.33.
@@ -23,4 +28,29 @@ function convertToCSSPTValue(styleValue) {
     value = PX_TO_PT_RATIO * value;
   }
   return value;
+}
+
+function toClosestFontPtSize(styleValue) {
+  var originalPTValue = convertToCSSPTValue(styleValue);
+
+  if (_FontSizeCommandMenuButton.FONT_PT_SIZES.includes(originalPTValue)) {
+    return originalPTValue;
+  }
+
+  var largerValueIndex = _FontSizeCommandMenuButton.FONT_PT_SIZES.findIndex(function (element) {
+    return element > originalPTValue;
+  });
+  if (largerValueIndex < 0) {
+    return _FontSizeCommandMenuButton.FONT_PT_SIZES[_FontSizeCommandMenuButton.FONT_PT_SIZES.length - 1];
+  } else if (largerValueIndex === 0) {
+    return _FontSizeCommandMenuButton.FONT_PT_SIZES[0];
+  } else {
+    var largerValue = _FontSizeCommandMenuButton.FONT_PT_SIZES[largerValueIndex];
+    var smallerValue = _FontSizeCommandMenuButton.FONT_PT_SIZES[largerValueIndex - 1];
+    if (largerValue - originalPTValue < originalPTValue - smallerValue) {
+      return largerValue;
+    } else {
+      return smallerValue;
+    }
+  }
 }

--- a/dist/convertToCSSPTValue.js
+++ b/dist/convertToCSSPTValue.js
@@ -37,20 +37,7 @@ function toClosestFontPtSize(styleValue) {
     return originalPTValue;
   }
 
-  var largerValueIndex = _FontSizeCommandMenuButton.FONT_PT_SIZES.findIndex(function (element) {
-    return element > originalPTValue;
-  });
-  if (largerValueIndex < 0) {
-    return _FontSizeCommandMenuButton.FONT_PT_SIZES[_FontSizeCommandMenuButton.FONT_PT_SIZES.length - 1];
-  } else if (largerValueIndex === 0) {
-    return _FontSizeCommandMenuButton.FONT_PT_SIZES[0];
-  } else {
-    var largerValue = _FontSizeCommandMenuButton.FONT_PT_SIZES[largerValueIndex];
-    var smallerValue = _FontSizeCommandMenuButton.FONT_PT_SIZES[largerValueIndex - 1];
-    if (largerValue - originalPTValue < originalPTValue - smallerValue) {
-      return largerValue;
-    } else {
-      return smallerValue;
-    }
-  }
+  return _FontSizeCommandMenuButton.FONT_PT_SIZES.reduce(function (prev, curr) {
+    return Math.abs(curr - originalPTValue) < Math.abs(prev - originalPTValue) ? curr : prev;
+  }, Number.NEGATIVE_INFINITY);
 }

--- a/dist/convertToCSSPTValue.js.flow
+++ b/dist/convertToCSSPTValue.js.flow
@@ -30,18 +30,7 @@ export function toClosestFontPtSize(styleValue: string): number {
     return originalPTValue;
   }
 
-  const largerValueIndex = FONT_PT_SIZES.findIndex(element => element > originalPTValue);
-  if (largerValueIndex < 0) {
-    return FONT_PT_SIZES[FONT_PT_SIZES.length - 1];
-  } else if (largerValueIndex === 0) {
-    return FONT_PT_SIZES[0];
-  } else {
-    const largerValue = FONT_PT_SIZES[largerValueIndex];
-    const smallerValue = FONT_PT_SIZES[largerValueIndex - 1];
-    if (largerValue - originalPTValue < originalPTValue - smallerValue) {
-      return largerValue;
-    } else {
-      return smallerValue;
-    }
-  }
+  return FONT_PT_SIZES.reduce((prev, curr) => {
+    return Math.abs(curr - originalPTValue) < Math.abs(prev - originalPTValue) ? curr : prev;
+  }, Number.NEGATIVE_INFINITY);
 }

--- a/dist/convertToCSSPTValue.js.flow
+++ b/dist/convertToCSSPTValue.js.flow
@@ -1,5 +1,7 @@
 // @flow
 
+import {FONT_PT_SIZES} from './ui/FontSizeCommandMenuButton';
+
 const SIZE_PATTERN = /([\d\.]+)(px|pt)/i;
 
 export const PX_TO_PT_RATIO = 0.7518796992481203; // 1 / 1.33.
@@ -19,4 +21,27 @@ export default function convertToCSSPTValue(styleValue: string): number {
     value = PX_TO_PT_RATIO * value;
   }
   return value;
+}
+
+export function toClosestFontPtSize(styleValue: string): number {
+  const originalPTValue = convertToCSSPTValue(styleValue);
+
+  if (FONT_PT_SIZES.includes(originalPTValue)) {
+    return originalPTValue;
+  }
+
+  const largerValueIndex = FONT_PT_SIZES.findIndex(element => element > originalPTValue);
+  if (largerValueIndex < 0) {
+    return FONT_PT_SIZES[FONT_PT_SIZES.length - 1];
+  } else if (largerValueIndex === 0) {
+    return FONT_PT_SIZES[0];
+  } else {
+    const largerValue = FONT_PT_SIZES[largerValueIndex];
+    const smallerValue = FONT_PT_SIZES[largerValueIndex - 1];
+    if (largerValue - originalPTValue < originalPTValue - smallerValue) {
+      return largerValue;
+    } else {
+      return smallerValue;
+    }
+  }
 }

--- a/dist/ui/FontSizeCommandMenuButton.js
+++ b/dist/ui/FontSizeCommandMenuButton.js
@@ -3,6 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.FONT_PT_SIZES = undefined;
 
 var _getPrototypeOf = require('babel-runtime/core-js/object/get-prototype-of');
 
@@ -48,7 +49,7 @@ var _findActiveFontSize2 = _interopRequireDefault(_findActiveFontSize);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var FONT_PT_SIZES = [8, 9, 10, 11, 12, 14, 18, 24, 30, 36, 48, 60, 72, 90];
+var FONT_PT_SIZES = exports.FONT_PT_SIZES = [8, 9, 10, 11, 12, 14, 18, 24, 30, 36, 48, 60, 72, 90];
 
 var FONT_PT_SIZE_COMMANDS = FONT_PT_SIZES.reduce(function (memo, size) {
   memo[' ' + size + ' '] = new _FontSizeCommand2.default(size);

--- a/dist/ui/FontSizeCommandMenuButton.js.flow
+++ b/dist/ui/FontSizeCommandMenuButton.js.flow
@@ -9,7 +9,7 @@ import FontSizeCommand from '../FontSizeCommand';
 import CommandMenuButton from './CommandMenuButton';
 import findActiveFontSize from './findActiveFontSize';
 
-const FONT_PT_SIZES = [8, 9, 10, 11, 12, 14, 18, 24, 30, 36, 48, 60, 72, 90];
+export const FONT_PT_SIZES = [8, 9, 10, 11, 12, 14, 18, 24, 30, 36, 48, 60, 72, 90];
 
 const FONT_PT_SIZE_COMMANDS = FONT_PT_SIZES.reduce((memo, size) => {
   memo[` ${size} `] = new FontSizeCommand(size);

--- a/src/FontSizeMarkSpec.js
+++ b/src/FontSizeMarkSpec.js
@@ -2,7 +2,7 @@
 
 import {Node} from 'prosemirror-model';
 
-import convertToCSSPTValue from './convertToCSSPTValue';
+import {toClosestFontPtSize} from './convertToCSSPTValue';
 
 import type {MarkSpec} from './Types';
 
@@ -31,7 +31,7 @@ function getAttrs(fontSize: string): Object {
     return attrs;
   }
 
-  const ptValue = convertToCSSPTValue(fontSize);
+  const ptValue = toClosestFontPtSize(fontSize);
   if (!ptValue) {
     return attrs;
   }

--- a/src/convertToCSSPTValue.js
+++ b/src/convertToCSSPTValue.js
@@ -30,18 +30,7 @@ export function toClosestFontPtSize(styleValue: string): number {
     return originalPTValue;
   }
 
-  const largerValueIndex = FONT_PT_SIZES.findIndex(element => element > originalPTValue);
-  if (largerValueIndex < 0) {
-    return FONT_PT_SIZES[FONT_PT_SIZES.length - 1];
-  } else if (largerValueIndex === 0) {
-    return FONT_PT_SIZES[0];
-  } else {
-    const largerValue = FONT_PT_SIZES[largerValueIndex];
-    const smallerValue = FONT_PT_SIZES[largerValueIndex - 1];
-    if (largerValue - originalPTValue < originalPTValue - smallerValue) {
-      return largerValue;
-    } else {
-      return smallerValue;
-    }
-  }
+  return FONT_PT_SIZES.reduce((prev, curr) => {
+    return Math.abs(curr - originalPTValue) < Math.abs(prev - originalPTValue) ? curr : prev;
+  }, Number.NEGATIVE_INFINITY);
 }

--- a/src/convertToCSSPTValue.js
+++ b/src/convertToCSSPTValue.js
@@ -1,5 +1,7 @@
 // @flow
 
+import {FONT_PT_SIZES} from './ui/FontSizeCommandMenuButton';
+
 const SIZE_PATTERN = /([\d\.]+)(px|pt)/i;
 
 export const PX_TO_PT_RATIO = 0.7518796992481203; // 1 / 1.33.
@@ -19,4 +21,27 @@ export default function convertToCSSPTValue(styleValue: string): number {
     value = PX_TO_PT_RATIO * value;
   }
   return value;
+}
+
+export function toClosestFontPtSize(styleValue: string): number {
+  const originalPTValue = convertToCSSPTValue(styleValue);
+
+  if (FONT_PT_SIZES.includes(originalPTValue)) {
+    return originalPTValue;
+  }
+
+  const largerValueIndex = FONT_PT_SIZES.findIndex(element => element > originalPTValue);
+  if (largerValueIndex < 0) {
+    return FONT_PT_SIZES[FONT_PT_SIZES.length - 1];
+  } else if (largerValueIndex === 0) {
+    return FONT_PT_SIZES[0];
+  } else {
+    const largerValue = FONT_PT_SIZES[largerValueIndex];
+    const smallerValue = FONT_PT_SIZES[largerValueIndex - 1];
+    if (largerValue - originalPTValue < originalPTValue - smallerValue) {
+      return largerValue;
+    } else {
+      return smallerValue;
+    }
+  }
 }

--- a/src/ui/FontSizeCommandMenuButton.js
+++ b/src/ui/FontSizeCommandMenuButton.js
@@ -9,7 +9,7 @@ import FontSizeCommand from '../FontSizeCommand';
 import CommandMenuButton from './CommandMenuButton';
 import findActiveFontSize from './findActiveFontSize';
 
-const FONT_PT_SIZES = [8, 9, 10, 11, 12, 14, 18, 24, 30, 36, 48, 60, 72, 90];
+export const FONT_PT_SIZES = [8, 9, 10, 11, 12, 14, 18, 24, 30, 36, 48, 60, 72, 90];
 
 const FONT_PT_SIZE_COMMANDS = FONT_PT_SIZES.reduce((memo, size) => {
   memo[` ${size} `] = new FontSizeCommand(size);


### PR DESCRIPTION
Original test case from demo doc:
![Screen Shot 2019-04-05 at 1 29 46 PM](https://user-images.githubusercontent.com/1837091/55655496-40d06700-57a9-11e9-93ea-18661ef2e00d.png)

Pasted and rounded:
![Screen Shot 2019-04-05 at 1 30 52 PM](https://user-images.githubusercontent.com/1837091/55655519-4c239280-57a9-11e9-9adc-986f6e119280.png)

Test HTML to paste with various font sizes:
![Screen Shot 2019-04-05 at 1 38 14 PM](https://user-images.githubusercontent.com/1837091/55655636-9e64b380-57a9-11e9-87f4-d9ccec1e0064.png)

Pasted and rounded:
![fontsize](https://user-images.githubusercontent.com/1837091/55655605-812fe500-57a9-11e9-9ab5-e809f073b813.gif)


