### PR TITLE
Revert "Always include data-layout attribute."

### DIFF
--- a/dist/EditorPageLayoutPlugin.js
+++ b/dist/EditorPageLayoutPlugin.js
@@ -54,8 +54,9 @@ function renderAttributes(editorState) {
       style += 'padding-right: ' + padding + 'pt;';
     }
     attrs.style = style;
+  } else {
+    attrs[_DocNodeSpec.ATTRIBUTE_LAYOUT] = layout || _DocNodeSpec.LAYOUT.US_LETTER_PORTRAIT;
   }
-  attrs[_DocNodeSpec.ATTRIBUTE_LAYOUT] = layout || _DocNodeSpec.LAYOUT.US_LETTER_PORTRAIT;
   return attrs;
 }
 

--- a/dist/EditorPageLayoutPlugin.js.flow
+++ b/dist/EditorPageLayoutPlugin.js.flow
@@ -27,8 +27,9 @@ function renderAttributes(editorState: EditorState): Object {
       style += `padding-right: ${padding}pt;`;
     }
     attrs.style = style;
+  } else {
+    attrs[ATTRIBUTE_LAYOUT] = layout || LAYOUT.US_LETTER_PORTRAIT;
   }
-  attrs[ATTRIBUTE_LAYOUT] = layout || LAYOUT.US_LETTER_PORTRAIT;
   return attrs;
 }
 

--- a/src/EditorPageLayoutPlugin.js
+++ b/src/EditorPageLayoutPlugin.js
@@ -27,8 +27,9 @@ function renderAttributes(editorState: EditorState): Object {
       style += `padding-right: ${padding}pt;`;
     }
     attrs.style = style;
+  } else {
+    attrs[ATTRIBUTE_LAYOUT] = layout || LAYOUT.US_LETTER_PORTRAIT;
   }
-  attrs[ATTRIBUTE_LAYOUT] = layout || LAYOUT.US_LETTER_PORTRAIT;
   return attrs;
 }
 


### PR DESCRIPTION
Reverting since the original PR wasn't ready to merge.