### PR TITLE
Fix typos and remove console.log in table resizing plugin

### DIFF
--- a/dist/TablePlugins.js
+++ b/dist/TablePlugins.js
@@ -10,12 +10,12 @@ var _TableCellMenuPlugin = require('./TableCellMenuPlugin');
 
 var _TableCellMenuPlugin2 = _interopRequireDefault(_TableCellMenuPlugin);
 
-var _createTableResizingPluging = require('./createTableResizingPluging');
+var _createTableResizingPlugin = require('./createTableResizingPlugin');
 
-var _createTableResizingPluging2 = _interopRequireDefault(_createTableResizingPluging);
+var _createTableResizingPlugin2 = _interopRequireDefault(_createTableResizingPlugin);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 // Tables
 // https://github.com/ProseMirror/prosemirror-tables/blob/master/demo.js
-exports.default = [new _TableCellMenuPlugin2.default(), (0, _createTableResizingPluging2.default)(), (0, _prosemirrorTables.tableEditing)()];
+exports.default = [new _TableCellMenuPlugin2.default(), (0, _createTableResizingPlugin2.default)(), (0, _prosemirrorTables.tableEditing)()];

--- a/dist/TablePlugins.js.flow
+++ b/dist/TablePlugins.js.flow
@@ -3,12 +3,12 @@
 import {tableEditing} from 'prosemirror-tables';
 
 import TableCellMenuPlugin from './TableCellMenuPlugin';
-import createTableResizingPluging from './createTableResizingPluging';
+import createTableResizingPlugin from './createTableResizingPlugin';
 
 // Tables
 // https://github.com/ProseMirror/prosemirror-tables/blob/master/demo.js
 export default [
   new TableCellMenuPlugin(),
-  createTableResizingPluging(),
+  createTableResizingPlugin(),
   tableEditing(),
 ];

--- a/dist/createTableResizingPlugin.js
+++ b/dist/createTableResizingPlugin.js
@@ -8,7 +8,7 @@ var _assign = require('babel-runtime/core-js/object/assign');
 
 var _assign2 = _interopRequireDefault(_assign);
 
-exports.default = createTableResizingPluging;
+exports.default = createTableResizingPlugin;
 
 var _prosemirrorState = require('prosemirror-state');
 
@@ -58,14 +58,13 @@ function calculateMaxClientX(event, targetTable) {
   return Math.round(clientX + Math.max(0, cx));
 }
 
-function createTableResizingPluging() {
+function createTableResizingPlugin() {
   var maxClientX = 0;
 
   // https://github.com/ProseMirror/prosemirror-tables/blob/master/src/columnresizing.js
   var plugin = (0, _prosemirrorTables.columnResizing)(TABLE_HANDLE_WIDTH, TABLE_CELL_MINWIDTH, TABLE_VIEW, TABLE_LAST_COLUMN_RESIZABLE);
 
   var captureMouse = function captureMouse(event) {
-    console.log([event.clientX, maxClientX]);
     if (event.clientX > maxClientX) {
       // Current mouse event will make table too wide. Stop it and
       // fires a simulated event instead.

--- a/dist/createTableResizingPlugin.js.flow
+++ b/dist/createTableResizingPlugin.js.flow
@@ -44,7 +44,7 @@ function calculateMaxClientX(
   return Math.round(clientX + Math.max(0, cx));
 }
 
-export default function createTableResizingPluging(): Plugin {
+export default function createTableResizingPlugin(): Plugin {
   let maxClientX = 0;
 
   // https://github.com/ProseMirror/prosemirror-tables/blob/master/src/columnresizing.js
@@ -56,7 +56,6 @@ export default function createTableResizingPluging(): Plugin {
   );
 
   const captureMouse = (event: any): void => {
-    console.log([event.clientX, maxClientX]);
     if (event.clientX > maxClientX) {
       // Current mouse event will make table too wide. Stop it and
       // fires a simulated event instead.

--- a/dist/ui/czi-table.css
+++ b/dist/ui/czi-table.css
@@ -7,7 +7,7 @@
 }
 
 .ProseMirror table {
-  border-collapse: none;
+  border-collapse: initial;
   border-spacing: 0;
   border: 1px solid var(--czi-table-border-color);
   border-width: 0 1px 1px 0;

--- a/src/TablePlugins.js
+++ b/src/TablePlugins.js
@@ -3,12 +3,12 @@
 import {tableEditing} from 'prosemirror-tables';
 
 import TableCellMenuPlugin from './TableCellMenuPlugin';
-import createTableResizingPluging from './createTableResizingPluging';
+import createTableResizingPlugin from './createTableResizingPlugin';
 
 // Tables
 // https://github.com/ProseMirror/prosemirror-tables/blob/master/demo.js
 export default [
   new TableCellMenuPlugin(),
-  createTableResizingPluging(),
+  createTableResizingPlugin(),
   tableEditing(),
 ];

--- a/src/createTableResizingPlugin.js
+++ b/src/createTableResizingPlugin.js
@@ -44,7 +44,7 @@ function calculateMaxClientX(
   return Math.round(clientX + Math.max(0, cx));
 }
 
-export default function createTableResizingPluging(): Plugin {
+export default function createTableResizingPlugin(): Plugin {
   let maxClientX = 0;
 
   // https://github.com/ProseMirror/prosemirror-tables/blob/master/src/columnresizing.js
@@ -56,7 +56,6 @@ export default function createTableResizingPluging(): Plugin {
   );
 
   const captureMouse = (event: any): void => {
-    console.log([event.clientX, maxClientX]);
     if (event.clientX > maxClientX) {
       // Current mouse event will make table too wide. Stop it and
       // fires a simulated event instead.

--- a/src/ui/czi-table.css
+++ b/src/ui/czi-table.css
@@ -7,7 +7,7 @@
 }
 
 .ProseMirror table {
-  border-collapse: none;
+  border-collapse: initial;
   border-spacing: 0;
   border: 1px solid var(--czi-table-border-color);
   border-width: 0 1px 1px 0;


### PR DESCRIPTION
I noticed in `latest` that there was something getting repeatedly logged in the console. Also noticed the filename typo when I was cleaning up the console.log. @hedgerwang we should consider consistent code reviews for this repo as well.