### PR TITLE
Only apply default min-height to editor pages

### DIFF
--- a/dist/ui/czi-editor.css
+++ b/dist/ui/czi-editor.css
@@ -65,7 +65,7 @@
   z-index: 1;
 }
 
-.ProseMirror,
+.ProseMirror.czi-prosemirror-editor,
 .ProseMirror[data-layout="us_letter_portrait"] {
   min-height: 279mm;
   padding: 15.5mm;

--- a/src/ui/czi-editor.css
+++ b/src/ui/czi-editor.css
@@ -65,7 +65,7 @@
   z-index: 1;
 }
 
-.ProseMirror,
+.ProseMirror.czi-prosemirror-editor,
 .ProseMirror[data-layout="us_letter_portrait"] {
   min-height: 279mm;
   padding: 15.5mm;


### PR DESCRIPTION
Following up on https://github.com/chanzuckerberg/czi-prosemirror/pull/37 and https://github.com/chanzuckerberg/czi-prosemirror/commit/153bf84c17b70d555a9c8f991e07406d02edec6b