### PR TITLE
[fix] Fix copy-paste within doc in Firefox

### DIFF
--- a/dist/toSafeHTMLDocument.js
+++ b/dist/toSafeHTMLDocument.js
@@ -6,16 +6,17 @@ Object.defineProperty(exports, "__esModule", {
 exports.default = toSafeHTMLDocument;
 
 
-// Provides a dom node that will not execute scripts
+// Parses HTML in a detached document to help with avoiding XSS
 // https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation.createHTMLDocument
 // https://developer.mozilla.org/en-US/Add-ons/Code_snippets/HTML_to_DOM
+// https://github.com/ProseMirror/prosemirror/issues/473#issuecomment-255727531
 function toSafeHTMLDocument(html) {
 
   if (typeof document !== 'undefined' && document.implementation && document.implementation.createHTMLDocument) {
     var doc = document.implementation.createHTMLDocument('');
-    doc.open();
-    doc.write(html);
-    doc.close();
+    if (doc.body) {
+      doc.body.innerHTML = html;
+    }
     return doc;
   }
   return null;

--- a/dist/toSafeHTMLDocument.js
+++ b/dist/toSafeHTMLDocument.js
@@ -7,8 +7,7 @@ exports.default = toSafeHTMLDocument;
 
 
 // Parses HTML in a detached document to help with avoiding XSS
-// https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation.createHTMLDocument
-// https://developer.mozilla.org/en-US/Add-ons/Code_snippets/HTML_to_DOM
+// https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Code_snippets/HTML_to_DOM
 // https://github.com/ProseMirror/prosemirror/issues/473#issuecomment-255727531
 function toSafeHTMLDocument(html) {
   var parser = new window.DOMParser();

--- a/dist/toSafeHTMLDocument.js
+++ b/dist/toSafeHTMLDocument.js
@@ -11,13 +11,6 @@ exports.default = toSafeHTMLDocument;
 // https://developer.mozilla.org/en-US/Add-ons/Code_snippets/HTML_to_DOM
 // https://github.com/ProseMirror/prosemirror/issues/473#issuecomment-255727531
 function toSafeHTMLDocument(html) {
-
-  if (typeof document !== 'undefined' && document.implementation && document.implementation.createHTMLDocument) {
-    var doc = document.implementation.createHTMLDocument('');
-    if (doc.body) {
-      doc.body.innerHTML = html;
-    }
-    return doc;
-  }
-  return null;
+  var parser = new window.DOMParser();
+  return parser.parseFromString(html, 'text/html');
 }

--- a/dist/toSafeHTMLDocument.js.flow
+++ b/dist/toSafeHTMLDocument.js.flow
@@ -1,9 +1,10 @@
 // @flow
 
 
-// Provides a dom node that will not execute scripts
+// Parses HTML in a detached document to help with avoiding XSS
 // https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation.createHTMLDocument
 // https://developer.mozilla.org/en-US/Add-ons/Code_snippets/HTML_to_DOM
+// https://github.com/ProseMirror/prosemirror/issues/473#issuecomment-255727531
 export default function toSafeHTMLDocument(html: string): ?Document {
 
   if (
@@ -12,9 +13,9 @@ export default function toSafeHTMLDocument(html: string): ?Document {
     document.implementation.createHTMLDocument
   ) {
     const doc = document.implementation.createHTMLDocument('');
-    doc.open();
-    doc.write(html);
-    doc.close();
+    if (doc.body) {
+      doc.body.innerHTML = html;
+    }
     return doc;
   }
   return null;

--- a/dist/toSafeHTMLDocument.js.flow
+++ b/dist/toSafeHTMLDocument.js.flow
@@ -2,8 +2,7 @@
 
 
 // Parses HTML in a detached document to help with avoiding XSS
-// https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation.createHTMLDocument
-// https://developer.mozilla.org/en-US/Add-ons/Code_snippets/HTML_to_DOM
+// https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Code_snippets/HTML_to_DOM
 // https://github.com/ProseMirror/prosemirror/issues/473#issuecomment-255727531
 export default function toSafeHTMLDocument(html: string): ?Document {
   const parser = new window.DOMParser();

--- a/dist/toSafeHTMLDocument.js.flow
+++ b/dist/toSafeHTMLDocument.js.flow
@@ -6,17 +6,6 @@
 // https://developer.mozilla.org/en-US/Add-ons/Code_snippets/HTML_to_DOM
 // https://github.com/ProseMirror/prosemirror/issues/473#issuecomment-255727531
 export default function toSafeHTMLDocument(html: string): ?Document {
-
-  if (
-    typeof document !== 'undefined' &&
-    document.implementation &&
-    document.implementation.createHTMLDocument
-  ) {
-    const doc = document.implementation.createHTMLDocument('');
-    if (doc.body) {
-      doc.body.innerHTML = html;
-    }
-    return doc;
-  }
-  return null;
+  const parser = new window.DOMParser();
+  return parser.parseFromString(html, 'text/html');
 }

--- a/src/toSafeHTMLDocument.js
+++ b/src/toSafeHTMLDocument.js
@@ -1,9 +1,10 @@
 // @flow
 
 
-// Provides a dom node that will not execute scripts
+// Parses HTML in a detached document to help with avoiding XSS
 // https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation.createHTMLDocument
 // https://developer.mozilla.org/en-US/Add-ons/Code_snippets/HTML_to_DOM
+// https://github.com/ProseMirror/prosemirror/issues/473#issuecomment-255727531
 export default function toSafeHTMLDocument(html: string): ?Document {
 
   if (
@@ -12,9 +13,9 @@ export default function toSafeHTMLDocument(html: string): ?Document {
     document.implementation.createHTMLDocument
   ) {
     const doc = document.implementation.createHTMLDocument('');
-    doc.open();
-    doc.write(html);
-    doc.close();
+    if (doc.body) {
+      doc.body.innerHTML = html;
+    }
     return doc;
   }
   return null;

--- a/src/toSafeHTMLDocument.js
+++ b/src/toSafeHTMLDocument.js
@@ -2,8 +2,7 @@
 
 
 // Parses HTML in a detached document to help with avoiding XSS
-// https://developer.mozilla.org/en-US/docs/Web/API/DOMImplementation.createHTMLDocument
-// https://developer.mozilla.org/en-US/Add-ons/Code_snippets/HTML_to_DOM
+// https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Code_snippets/HTML_to_DOM
 // https://github.com/ProseMirror/prosemirror/issues/473#issuecomment-255727531
 export default function toSafeHTMLDocument(html: string): ?Document {
   const parser = new window.DOMParser();

--- a/src/toSafeHTMLDocument.js
+++ b/src/toSafeHTMLDocument.js
@@ -6,17 +6,6 @@
 // https://developer.mozilla.org/en-US/Add-ons/Code_snippets/HTML_to_DOM
 // https://github.com/ProseMirror/prosemirror/issues/473#issuecomment-255727531
 export default function toSafeHTMLDocument(html: string): ?Document {
-
-  if (
-    typeof document !== 'undefined' &&
-    document.implementation &&
-    document.implementation.createHTMLDocument
-  ) {
-    const doc = document.implementation.createHTMLDocument('');
-    if (doc.body) {
-      doc.body.innerHTML = html;
-    }
-    return doc;
-  }
-  return null;
+  const parser = new window.DOMParser();
+  return parser.parseFromString(html, 'text/html');
 }


### PR DESCRIPTION
`document.write` was not working properly in Firefox. 
Security of `innerHTML` - https://developer.mozilla.org/en-US/docs/Web/API/Element/innerHTML#Security_considerations
The `innerHTML` spec specifies that `<script>` should not execute, but there can still be other risks. This is at least matching what `prosemirror` is doing: 
https://github.com/ProseMirror/prosemirror/issues/473#issuecomment-255727531
https://github.com/ProseMirror/prosemirror-view/commit/0f9d341d30175bab77670ef8016c8b25079b56d6

Verified that copy-paste now works in Firefox (attached). Also verified in Safari and Chrome
![ff-copy-paste](https://user-images.githubusercontent.com/1837091/56524728-cb7dc980-64fe-11e9-9733-80c3d45df247.gif)