### PR TITLE
[EASY] Fix script that builds the demo assets.

### DIFF
--- a/build_bin.py
+++ b/build_bin.py
@@ -58,7 +58,7 @@ def main():
   print '-' * 80
   os.system('killall -9 node')
   os.system('rm -fr bin')
-  os.system('NODE_ENV=production npm run build_bin')
+  os.system('NODE_ENV=production npm run app:build')
 
   # ls # BUG: os.system('cp web_app/web_runtime.bundle.js bin/web_runtime.js')
 


### PR DESCRIPTION
The recent the clean up works rename the script command `build_bin` to `app:build`.
This fixes the tool that calls the script.