### PR TITLE
Fix math editor

### DIFF
--- a/src/ui/MathInlineEditor.js
+++ b/src/ui/MathInlineEditor.js
@@ -1,13 +1,11 @@
 // @flow
 
-import React from 'react';
-
+import './czi-inline-editor.css';
 import CustomButton from './CustomButton';
 import CustomEditorView from './CustomEditorView';
 import MathEditor from './MathEditor';
+import React from 'react';
 import createPopUp from './createPopUp';
-
-import './czi-inline-editor.css';
 
 const MathAlignValues = {
   NONE: {

--- a/src/ui/MathInlineEditor.js
+++ b/src/ui/MathInlineEditor.js
@@ -9,8 +9,6 @@ import createPopUp from './createPopUp';
 
 import './czi-inline-editor.css';
 
-import type {PopUpHandle} from './createPopUp';
-
 const MathAlignValues = {
   NONE: {
     value: null,
@@ -30,7 +28,7 @@ export type MathInlineEditorValue = {
 class MathInlineEditor extends React.PureComponent<any, any, any> {
   props: {
     onEditEnd: () => void,
-    onEditStart: (h: PopUpHandle) => void,
+    onEditStart: () => void,
     onSelect: (val: MathInlineEditorValue) => void,
     value: ?MathInlineEditorValue,
     editorView: ?CustomEditorView,
@@ -99,7 +97,7 @@ class MathInlineEditor extends React.PureComponent<any, any, any> {
         }
       },
     });
-    this.props.onEditStart(this._popUp);
+    this.props.onEditStart();
   };
 }
 

--- a/src/ui/MathInlineEditor.js
+++ b/src/ui/MathInlineEditor.js
@@ -1,29 +1,25 @@
 // @flow
 
-import './czi-inline-editor.css';
+import React from 'react';
+
 import CustomButton from './CustomButton';
 import CustomEditorView from './CustomEditorView';
 import MathEditor from './MathEditor';
-import React from 'react';
 import createPopUp from './createPopUp';
+
+import './czi-inline-editor.css';
+
+import type {PopUpHandle} from './createPopUp';
 
 const MathAlignValues = {
   NONE: {
     value: null,
     text: 'Inline',
   },
-  // LEFT: {
-  //   value: 'left',
-  //   text: 'Float left',
-  // },
   CENTER: {
     value: 'center',
     text: 'Break text',
   },
-  // RIGHT: {
-  //   value: 'right',
-  //   text: 'Float right',
-  // },
 };
 
 export type MathInlineEditorValue = {
@@ -33,6 +29,8 @@ export type MathInlineEditorValue = {
 
 class MathInlineEditor extends React.PureComponent<any, any, any> {
   props: {
+    onEditEnd: () => void,
+    onEditStart: (h: PopUpHandle) => void,
     onSelect: (val: MathInlineEditorValue) => void,
     value: ?MathInlineEditorValue,
     editorView: ?CustomEditorView,
@@ -88,6 +86,7 @@ class MathInlineEditor extends React.PureComponent<any, any, any> {
       initialValue: (value && value.latex) || '',
     };
     this._popUp = createPopUp(MathEditor, props, {
+      autoDismiss: false,
       modal: true,
       onClose: latex => {
         if (this._popUp) {
@@ -96,9 +95,11 @@ class MathInlineEditor extends React.PureComponent<any, any, any> {
             const value = this.props.value || {};
             this.props.onSelect({...value, latex});
           }
+          this.props.onEditEnd();
         }
       },
     });
+    this.props.onEditStart(this._popUp);
   };
 }
 

--- a/src/ui/MathNodeView.js
+++ b/src/ui/MathNodeView.js
@@ -16,7 +16,6 @@ import uuid from './uuid';
 import './czi-math-view.css';
 
 import type {NodeViewProps} from './CustomNodeView';
-import type {PopUpHandle} from './createPopUp';
 
 const EMPTY_SRC =
   'data:image/gif;base64,' +
@@ -26,7 +25,7 @@ class MathViewBody extends React.PureComponent<any, any, any> {
   props: NodeViewProps;
 
   state = {
-    equationEditor: null,
+    isEditing: false,
   };
 
   _inlineEditor = null;
@@ -52,9 +51,9 @@ class MathViewBody extends React.PureComponent<any, any, any> {
     const {node, selected, focused} = this.props;
     const {attrs} = node;
     const {latex} = attrs;
-    const {equationEditor} = this.state;
+    const {isEditing} = this.state;
 
-    const active = (focused || !!equationEditor) && !readOnly;
+    const active = (focused || isEditing) && !readOnly;
     const className = cx('czi-math-view-body', {active, selected});
     const html = renderLaTeXAsHTML(latex);
     return (
@@ -107,12 +106,12 @@ class MathViewBody extends React.PureComponent<any, any, any> {
     }
   }
 
-  _onEditStart = (equationEditor: PopUpHandle): void => {
-    this.setState({equationEditor});
+  _onEditStart = (): void => {
+    this.setState({isEdiing: true});
   };
 
   _onEditEnd = (): void => {
-    this.setState({equationEditor: null});
+    this.setState({isEdiing: false});
   };
 
   _onChange = (value: ?{align: ?string, latex: string}): void => {

--- a/src/ui/MathNodeView.js
+++ b/src/ui/MathNodeView.js
@@ -1,19 +1,17 @@
 // @flow
 
-import cx from 'classnames';
-import {Node} from 'prosemirror-model';
-import {Decoration} from 'prosemirror-view';
-import React from 'react';
-
+import './czi-math-view.css';
 import CustomNodeView from './CustomNodeView';
-import {FRAMESET_BODY_CLASSNAME} from './EditorFrameset';
 import MathInlineEditor from './MathInlineEditor';
-import {atAnchorBottomCenter} from './PopUpPosition';
+import React from 'react';
 import createPopUp from './createPopUp';
+import cx from 'classnames';
 import renderLaTeXAsHTML from './renderLaTeXAsHTML';
 import uuid from './uuid';
-
-import './czi-math-view.css';
+import {Decoration} from 'prosemirror-view';
+import {FRAMESET_BODY_CLASSNAME} from './EditorFrameset';
+import {Node} from 'prosemirror-model';
+import {atAnchorBottomCenter} from './PopUpPosition';
 
 import type {NodeViewProps} from './CustomNodeView';
 
@@ -107,11 +105,11 @@ class MathViewBody extends React.PureComponent<any, any, any> {
   }
 
   _onEditStart = (): void => {
-    this.setState({isEdiing: true});
+    this.setState({isEditing: true});
   };
 
   _onEditEnd = (): void => {
-    this.setState({isEdiing: false});
+    this.setState({isEditing: false});
   };
 
   _onChange = (value: ?{align: ?string, latex: string}): void => {


### PR DESCRIPTION
For now, opening the equation editor will take the focus away from the selected math element, which causes the equation editor to be closed again because the math element is not active.

This diff ensures that the math element can stay as active while user is editing the math content.

![mmmm](https://user-images.githubusercontent.com/1504439/56993025-3909a580-6b50-11e9-960a-37c8a6af4969.gif)
