### PR TITLE
Fix table resizing with margin-left.

### DIFF
--- a/dist/TableResizePlugin.js
+++ b/dist/TableResizePlugin.js
@@ -20,6 +20,10 @@ var _assign = require('babel-runtime/core-js/object/assign');
 
 var _assign2 = _interopRequireDefault(_assign);
 
+var _extends2 = require('babel-runtime/helpers/extends');
+
+var _extends3 = _interopRequireDefault(_extends2);
+
 var _from = require('babel-runtime/core-js/array/from');
 
 var _from2 = _interopRequireDefault(_from);
@@ -42,11 +46,17 @@ var _tablemap = require('prosemirror-tables/src/tablemap');
 
 var _tableview = require('prosemirror-tables/src/tableview');
 
-var _util = require('prosemirror-tables/src/util');
-
 var _prosemirrorTransform = require('prosemirror-transform');
 
 var _prosemirrorView = require('prosemirror-view');
+
+var _prosemirrorUtils = require('prosemirror-utils');
+
+var _util = require('prosemirror-tables/src/util');
+
+var _nullthrows = require('nullthrows');
+
+var _nullthrows2 = _interopRequireDefault(_nullthrows);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -281,7 +291,8 @@ function handleDragEnd(view, event) {
   if (!draggingInfo) {
     return;
   }
-  var columnElements = draggingInfo.columnElements;
+  var columnElements = draggingInfo.columnElements,
+      tableElement = draggingInfo.tableElement;
 
   var widths = (0, _from2.default)(columnElements).map(function (colEl) {
     return parseFloat(colEl.style.width);
@@ -316,6 +327,18 @@ function handleDragEnd(view, event) {
       tr = tr.setNodeMarkup(start + pos, null, (0, _util.setAttr)(attrs, 'colwidth', colwidth));
     }
   }
+
+  var marginLeft = parseFloat(tableElement.style.marginLeft) || null;
+  if (table.attrs.marginLeft !== marginLeft) {
+    var nodeType = table.type;
+    var _attrs = (0, _extends3.default)({}, table.attrs, {
+      marginLeft: marginLeft
+    });
+    var tableLookup = (0, _prosemirrorUtils.findParentNodeOfTypeClosestToPos)($cell, view.state.schema.nodes[nodeType.name]);
+    var tablePos = (0, _nullthrows2.default)(tableLookup && tableLookup.pos);
+    tr = tr.setNodeMarkup(tablePos, nodeType, _attrs);
+  }
+
   if (tr.docChanged) {
     // Let editor know the change.
     view.dispatch(tr);

--- a/dist/TableResizePlugin.js.flow
+++ b/dist/TableResizePlugin.js.flow
@@ -34,9 +34,11 @@ import {EditorState, Plugin, PluginKey} from 'prosemirror-state';
 import {tableNodeTypes} from 'prosemirror-tables/src/schema';
 import {TableMap} from 'prosemirror-tables/src/tablemap';
 import {TableView} from 'prosemirror-tables/src/tableview';
-import {cellAround, pointsAtCell, setAttr} from 'prosemirror-tables/src/util';
 import {Transform} from 'prosemirror-transform';
 import {Decoration, DecorationSet, EditorView} from 'prosemirror-view';
+import {findParentNodeOfTypeClosestToPos} from 'prosemirror-utils';
+import {cellAround, pointsAtCell, setAttr} from 'prosemirror-tables/src/util';
+import nullthrows from 'nullthrows';
 
 type DraggingInfo = {
   columnElements: Array<HTMLElement>,
@@ -267,7 +269,7 @@ function handleDragEnd(view: EditorView, event: PointerEvent): void {
   if (!draggingInfo) {
     return;
   }
-  const {columnElements} = draggingInfo;
+  const {columnElements, tableElement} = draggingInfo;
   const widths = Array.from(columnElements).map(colEl => {
     return parseFloat(colEl.style.width);
   });
@@ -304,6 +306,22 @@ function handleDragEnd(view: EditorView, event: PointerEvent): void {
       );
     }
   }
+
+  const marginLeft = parseFloat(tableElement.style.marginLeft) || null;
+  if (table.attrs.marginLeft !== marginLeft) {
+    const nodeType = table.type;
+    const attrs = {
+      ...table.attrs,
+      marginLeft,
+    };
+    const tableLookup = findParentNodeOfTypeClosestToPos(
+      $cell,
+      view.state.schema.nodes[nodeType.name]
+    );
+    const tablePos = nullthrows(tableLookup && tableLookup.pos);
+    tr = tr.setNodeMarkup(tablePos, nodeType, attrs);
+  }
+
   if (tr.docChanged) {
     // Let editor know the change.
     view.dispatch(tr);

--- a/src/TableResizePlugin.js
+++ b/src/TableResizePlugin.js
@@ -29,15 +29,15 @@
 // - Let user set the left margin of the table.
 // - Let user set the right margin of the table.
 
-import {Decoration, DecorationSet, EditorView} from 'prosemirror-view';
-import {EditorState, Plugin, PluginKey} from 'prosemirror-state';
 import {Node} from 'prosemirror-model';
+import {EditorState, Plugin, PluginKey} from 'prosemirror-state';
+import {tableNodeTypes} from 'prosemirror-tables/src/schema';
 import {TableMap} from 'prosemirror-tables/src/tablemap';
 import {TableView} from 'prosemirror-tables/src/tableview';
 import {Transform} from 'prosemirror-transform';
-import {cellAround, pointsAtCell, setAttr} from 'prosemirror-tables/src/util';
+import {Decoration, DecorationSet, EditorView} from 'prosemirror-view';
 import {findParentNodeOfTypeClosestToPos} from 'prosemirror-utils';
-import {tableNodeTypes} from 'prosemirror-tables/src/schema';
+import {cellAround, pointsAtCell, setAttr} from 'prosemirror-tables/src/util';
 import nullthrows from 'nullthrows';
 
 type DraggingInfo = {


### PR DESCRIPTION
**About**

After resizing the table, it should also update the attributes of the the table. 
For now, only the DOM element is updated, but table's attributes remain the same.

**Test Plan**

- go http://localhost:3001/convert.html
- insert a table
- resize the columns and left margin
- click "ProseMirror => JSON"
- verify that the JSON data is updated after resizing.

![image](https://user-images.githubusercontent.com/1504439/57100014-bc530480-6cd2-11e9-9607-fd196e17db29.png)
