### PR TITLE
Use forked "prosemirror-tables"

### DIFF
--- a/dist/TableResizePlugin.js
+++ b/dist/TableResizePlugin.js
@@ -20,10 +20,6 @@ var _assign = require('babel-runtime/core-js/object/assign');
 
 var _assign2 = _interopRequireDefault(_assign);
 
-var _extends2 = require('babel-runtime/helpers/extends');
-
-var _extends3 = _interopRequireDefault(_extends2);
-
 var _from = require('babel-runtime/core-js/array/from');
 
 var _from2 = _interopRequireDefault(_from);
@@ -46,17 +42,11 @@ var _tablemap = require('prosemirror-tables/src/tablemap');
 
 var _tableview = require('prosemirror-tables/src/tableview');
 
+var _util = require('prosemirror-tables/src/util');
+
 var _prosemirrorTransform = require('prosemirror-transform');
 
 var _prosemirrorView = require('prosemirror-view');
-
-var _prosemirrorUtils = require('prosemirror-utils');
-
-var _util = require('prosemirror-tables/src/util');
-
-var _nullthrows = require('nullthrows');
-
-var _nullthrows2 = _interopRequireDefault(_nullthrows);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -291,8 +281,7 @@ function handleDragEnd(view, event) {
   if (!draggingInfo) {
     return;
   }
-  var columnElements = draggingInfo.columnElements,
-      tableElement = draggingInfo.tableElement;
+  var columnElements = draggingInfo.columnElements;
 
   var widths = (0, _from2.default)(columnElements).map(function (colEl) {
     return parseFloat(colEl.style.width);
@@ -327,18 +316,6 @@ function handleDragEnd(view, event) {
       tr = tr.setNodeMarkup(start + pos, null, (0, _util.setAttr)(attrs, 'colwidth', colwidth));
     }
   }
-
-  var marginLeft = parseFloat(tableElement.style.marginLeft) || null;
-  if (table.attrs.marginLeft !== marginLeft) {
-    var nodeType = table.type;
-    var _attrs = (0, _extends3.default)({}, table.attrs, {
-      marginLeft: marginLeft
-    });
-    var tableLookup = (0, _prosemirrorUtils.findParentNodeOfTypeClosestToPos)($cell, view.state.schema.nodes[nodeType.name]);
-    var tablePos = (0, _nullthrows2.default)(tableLookup && tableLookup.pos);
-    tr = tr.setNodeMarkup(tablePos, nodeType, _attrs);
-  }
-
   if (tr.docChanged) {
     // Let editor know the change.
     view.dispatch(tr);

--- a/dist/TableResizePlugin.js
+++ b/dist/TableResizePlugin.js
@@ -4,22 +4,6 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _getPrototypeOf = require('babel-runtime/core-js/object/get-prototype-of');
-
-var _getPrototypeOf2 = _interopRequireDefault(_getPrototypeOf);
-
-var _possibleConstructorReturn2 = require('babel-runtime/helpers/possibleConstructorReturn');
-
-var _possibleConstructorReturn3 = _interopRequireDefault(_possibleConstructorReturn2);
-
-var _inherits2 = require('babel-runtime/helpers/inherits');
-
-var _inherits3 = _interopRequireDefault(_inherits2);
-
-var _assign = require('babel-runtime/core-js/object/assign');
-
-var _assign2 = _interopRequireDefault(_assign);
-
 var _extends2 = require('babel-runtime/helpers/extends');
 
 var _extends3 = _interopRequireDefault(_extends2);
@@ -28,6 +12,10 @@ var _from = require('babel-runtime/core-js/array/from');
 
 var _from2 = _interopRequireDefault(_from);
 
+var _getPrototypeOf = require('babel-runtime/core-js/object/get-prototype-of');
+
+var _getPrototypeOf2 = _interopRequireDefault(_getPrototypeOf);
+
 var _classCallCheck2 = require('babel-runtime/helpers/classCallCheck');
 
 var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
@@ -35,6 +23,18 @@ var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
 var _createClass2 = require('babel-runtime/helpers/createClass');
 
 var _createClass3 = _interopRequireDefault(_createClass2);
+
+var _possibleConstructorReturn2 = require('babel-runtime/helpers/possibleConstructorReturn');
+
+var _possibleConstructorReturn3 = _interopRequireDefault(_possibleConstructorReturn2);
+
+var _get2 = require('babel-runtime/helpers/get');
+
+var _get3 = _interopRequireDefault(_get2);
+
+var _inherits2 = require('babel-runtime/helpers/inherits');
+
+var _inherits3 = _interopRequireDefault(_inherits2);
 
 var _prosemirrorModel = require('prosemirror-model');
 
@@ -88,7 +88,32 @@ var PLUGIN_KEY = new _prosemirrorState.PluginKey('tableColumnResizing');
 var CELL_MIN_WIDTH = 25;
 var HANDLE_WIDTH = 20;
 
+// A custom table view that renders the margin-left style.
+
+var CustomTableView = function (_TableView) {
+  (0, _inherits3.default)(CustomTableView, _TableView);
+
+  function CustomTableView() {
+    (0, _classCallCheck3.default)(this, CustomTableView);
+    return (0, _possibleConstructorReturn3.default)(this, (CustomTableView.__proto__ || (0, _getPrototypeOf2.default)(CustomTableView)).apply(this, arguments));
+  }
+
+  (0, _createClass3.default)(CustomTableView, [{
+    key: 'update',
+    value: function update(node) {
+      var updated = (0, _get3.default)(CustomTableView.prototype.__proto__ || (0, _getPrototypeOf2.default)(CustomTableView.prototype), 'update', this).call(this, node);
+      if (updated) {
+        var marginLeft = node.attrs && node.attrs.marginLeft || 0;
+        this.table.style.marginLeft = marginLeft ? marginLeft + 'px' : '';
+      }
+      return updated;
+    }
+  }]);
+  return CustomTableView;
+}(_prosemirrorTables.TableView);
+
 // The immutable plugin state that stores the information for resizing.
+
 
 var ResizeState = function () {
   function ResizeState(cellPos, forMarginLeft, draggingInfo) {
@@ -487,23 +512,7 @@ function handleDecorations(state, resizeState) {
 
 // Creates a custom table view that renders the margin-left style.
 function createTableView(node, view) {
-  var tableView = new _prosemirrorTables.TableView(node, CELL_MIN_WIDTH, view);
-  var updateOriginal = tableView.update;
-  var updatePatched = function updatePatched(node) {
-    if (!updateOriginal.call(tableView, node)) {
-      return false;
-    }
-    var marginLeft = node.attrs && node.attrs.marginLeft || 0;
-    tableView.table.style.marginLeft = marginLeft ? marginLeft + 'px' : '';
-    return true;
-  };
-
-  (0, _assign2.default)(tableView, {
-    update: updatePatched
-  });
-
-  updatePatched(node);
-  return tableView;
+  return new CustomTableView(node, CELL_MIN_WIDTH, view);
 }
 
 function batchMouseHandler(handler) {

--- a/dist/TableResizePlugin.js.flow
+++ b/dist/TableResizePlugin.js.flow
@@ -34,11 +34,9 @@ import {EditorState, Plugin, PluginKey} from 'prosemirror-state';
 import {tableNodeTypes} from 'prosemirror-tables/src/schema';
 import {TableMap} from 'prosemirror-tables/src/tablemap';
 import {TableView} from 'prosemirror-tables/src/tableview';
+import {cellAround, pointsAtCell, setAttr} from 'prosemirror-tables/src/util';
 import {Transform} from 'prosemirror-transform';
 import {Decoration, DecorationSet, EditorView} from 'prosemirror-view';
-import {findParentNodeOfTypeClosestToPos} from 'prosemirror-utils';
-import {cellAround, pointsAtCell, setAttr} from 'prosemirror-tables/src/util';
-import nullthrows from 'nullthrows';
 
 type DraggingInfo = {
   columnElements: Array<HTMLElement>,
@@ -269,7 +267,7 @@ function handleDragEnd(view: EditorView, event: PointerEvent): void {
   if (!draggingInfo) {
     return;
   }
-  const {columnElements, tableElement} = draggingInfo;
+  const {columnElements} = draggingInfo;
   const widths = Array.from(columnElements).map(colEl => {
     return parseFloat(colEl.style.width);
   });
@@ -306,22 +304,6 @@ function handleDragEnd(view: EditorView, event: PointerEvent): void {
       );
     }
   }
-
-  const marginLeft = parseFloat(tableElement.style.marginLeft) || null;
-  if (table.attrs.marginLeft !== marginLeft) {
-    const nodeType = table.type;
-    const attrs = {
-      ...table.attrs,
-      marginLeft,
-    };
-    const tableLookup = findParentNodeOfTypeClosestToPos(
-      $cell,
-      view.state.schema.nodes[nodeType.name]
-    );
-    const tablePos = nullthrows(tableLookup && tableLookup.pos);
-    tr = tr.setNodeMarkup(tablePos, nodeType, attrs);
-  }
-
   if (tr.docChanged) {
     // Let editor know the change.
     view.dispatch(tr);

--- a/dist/TableResizePlugin.js.flow
+++ b/dist/TableResizePlugin.js.flow
@@ -31,12 +31,18 @@
 
 import {Node} from 'prosemirror-model';
 import {EditorState, Plugin, PluginKey} from 'prosemirror-state';
-import {tableNodeTypes} from 'prosemirror-tables/src/schema';
-import {TableMap} from 'prosemirror-tables/src/tablemap';
-import {TableView} from 'prosemirror-tables/src/tableview';
-import {cellAround, pointsAtCell, setAttr} from 'prosemirror-tables/src/util';
 import {Transform} from 'prosemirror-transform';
 import {Decoration, DecorationSet, EditorView} from 'prosemirror-view';
+import {findParentNodeOfTypeClosestToPos} from 'prosemirror-utils';
+import nullthrows from 'nullthrows';
+import {
+  cellAround,
+  pointsAtCell,
+  setAttr,
+  tableNodeTypes,
+  TableMap,
+  TableView,
+} from 'prosemirror-tables';
 
 type DraggingInfo = {
   columnElements: Array<HTMLElement>,
@@ -267,7 +273,7 @@ function handleDragEnd(view: EditorView, event: PointerEvent): void {
   if (!draggingInfo) {
     return;
   }
-  const {columnElements} = draggingInfo;
+  const {columnElements, tableElement} = draggingInfo;
   const widths = Array.from(columnElements).map(colEl => {
     return parseFloat(colEl.style.width);
   });
@@ -304,6 +310,22 @@ function handleDragEnd(view: EditorView, event: PointerEvent): void {
       );
     }
   }
+
+  const marginLeft = parseFloat(tableElement.style.marginLeft) || null;
+  if (table.attrs.marginLeft !== marginLeft) {
+    const nodeType = table.type;
+    const attrs = {
+      ...table.attrs,
+      marginLeft,
+    };
+    const tableLookup = findParentNodeOfTypeClosestToPos(
+      $cell,
+      view.state.schema.nodes[nodeType.name]
+    );
+    const tablePos = nullthrows(tableLookup && tableLookup.pos);
+    tr = tr.setNodeMarkup(tablePos, nodeType, attrs);
+  }
+
   if (tr.docChanged) {
     // Let editor know the change.
     view.dispatch(tr);

--- a/dist/TableResizePlugin.js.flow
+++ b/dist/TableResizePlugin.js.flow
@@ -65,6 +65,18 @@ const PLUGIN_KEY = new PluginKey('tableColumnResizing');
 const CELL_MIN_WIDTH = 25;
 const HANDLE_WIDTH = 20;
 
+// A custom table view that renders the margin-left style.
+class CustomTableView extends TableView {
+  update(node: Node): boolean {
+    const updated = super.update(node);
+    if (updated) {
+      const marginLeft = (node.attrs && node.attrs.marginLeft) || 0;
+      this.table.style.marginLeft = marginLeft ? `${marginLeft}px` : '';
+    }
+    return updated;
+  }
+}
+
 // The immutable plugin state that stores the information for resizing.
 class ResizeState {
   cellPos: ?number;
@@ -499,23 +511,7 @@ function handleDecorations(
 
 // Creates a custom table view that renders the margin-left style.
 function createTableView(node: Node, view: EditorView): TableView {
-  const tableView = new TableView(node, CELL_MIN_WIDTH, view);
-  const updateOriginal = tableView.update;
-  const updatePatched = function(node: Node): boolean {
-    if (!updateOriginal.call(tableView, node)) {
-      return false;
-    }
-    const marginLeft = (node.attrs && node.attrs.marginLeft) || 0;
-    tableView.table.style.marginLeft = marginLeft ? `${marginLeft}px` : '';
-    return true;
-  };
-
-  Object.assign(tableView, {
-    update: updatePatched,
-  });
-
-  updatePatched(node);
-  return tableView;
+  return new CustomTableView(node, CELL_MIN_WIDTH, view);
 }
 
 function batchMouseHandler(

--- a/package-lock.json
+++ b/package-lock.json
@@ -11639,9 +11639,7 @@
       }
     },
     "prosemirror-tables": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-0.7.9.tgz",
-      "integrity": "sha512-wCYnDdYMJPD3OdbBqn+Lv+lr4jL4scUTdP+ICSQpqLuvj7seFcTIRBw2o5yUW/ZaMQ5v9TqhFbicb8k/3wj8eg==",
+      "version": "github:chanzuckerberg/prosemirror-tables#2f2bd5eb94a640e3699ead6faa458c4a4d1e86c0",
       "requires": {
         "prosemirror-keymap": "1.0.1",
         "prosemirror-model": "1.6.3",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "prosemirror-model": "1.6.3",
     "prosemirror-schema-list": "1.0.1",
     "prosemirror-state": "1.2.2",
-    "prosemirror-tables": "0.7.9",
+    "prosemirror-tables": "github:chanzuckerberg/prosemirror-tables#2f2bd5eb94a640e3699ead6faa458c4a4d1e86c0",
     "prosemirror-transform": "1.1.3",
     "prosemirror-utils": "0.6.6",
     "prosemirror-view": "1.6.7",

--- a/src/TableResizePlugin.js
+++ b/src/TableResizePlugin.js
@@ -31,14 +31,18 @@
 
 import {Node} from 'prosemirror-model';
 import {EditorState, Plugin, PluginKey} from 'prosemirror-state';
-import {tableNodeTypes} from 'prosemirror-tables/src/schema';
-import {TableMap} from 'prosemirror-tables/src/tablemap';
-import {TableView} from 'prosemirror-tables/src/tableview';
 import {Transform} from 'prosemirror-transform';
 import {Decoration, DecorationSet, EditorView} from 'prosemirror-view';
 import {findParentNodeOfTypeClosestToPos} from 'prosemirror-utils';
-import {cellAround, pointsAtCell, setAttr} from 'prosemirror-tables/src/util';
 import nullthrows from 'nullthrows';
+import {
+  cellAround,
+  pointsAtCell,
+  setAttr,
+  tableNodeTypes,
+  TableMap,
+  TableView,
+} from 'prosemirror-tables';
 
 type DraggingInfo = {
   columnElements: Array<HTMLElement>,

--- a/src/TableResizePlugin.js
+++ b/src/TableResizePlugin.js
@@ -65,6 +65,18 @@ const PLUGIN_KEY = new PluginKey('tableColumnResizing');
 const CELL_MIN_WIDTH = 25;
 const HANDLE_WIDTH = 20;
 
+// A custom table view that renders the margin-left style.
+class CustomTableView extends TableView {
+  update(node: Node): boolean {
+    const updated = super.update(node);
+    if (updated) {
+      const marginLeft = (node.attrs && node.attrs.marginLeft) || 0;
+      this.table.style.marginLeft = marginLeft ? `${marginLeft}px` : '';
+    }
+    return updated;
+  }
+}
+
 // The immutable plugin state that stores the information for resizing.
 class ResizeState {
   cellPos: ?number;
@@ -499,23 +511,7 @@ function handleDecorations(
 
 // Creates a custom table view that renders the margin-left style.
 function createTableView(node: Node, view: EditorView): TableView {
-  const tableView = new TableView(node, CELL_MIN_WIDTH, view);
-  const updateOriginal = tableView.update;
-  const updatePatched = function(node: Node): boolean {
-    if (!updateOriginal.call(tableView, node)) {
-      return false;
-    }
-    const marginLeft = (node.attrs && node.attrs.marginLeft) || 0;
-    tableView.table.style.marginLeft = marginLeft ? `${marginLeft}px` : '';
-    return true;
-  };
-
-  Object.assign(tableView, {
-    update: updatePatched,
-  });
-
-  updatePatched(node);
-  return tableView;
+  return new CustomTableView(node, CELL_MIN_WIDTH, view);
 }
 
 function batchMouseHandler(


### PR DESCRIPTION
The default package of  "prosemirror-tables" does not export some utility functions that we need.

As a quick workaround, I forked the package and exports more utility functions that we need in https://github.com/chanzuckerberg/prosemirror-tables/commit/798082376c83f176231ff25589a944f64d24cb5a

The long term solution would be sending out an official PR to request the official "prosemirror-tables" to accept my changes and publish a new NPM version, but before that happen, we could just use the forked version. 