### PR TITLE
Clean up Math Symbols in Math Editor

### DIFF
--- a/demo/UIExamples.js
+++ b/demo/UIExamples.js
@@ -55,10 +55,6 @@ class MathEditorExample extends React.PureComponent<any, any, any> {
     );
   }
 
-  componentDidMount() {
-    setTimeout(this._onClick, 100);
-  }
-
   _onClick = (): void => {
     if (!this._popup) {
       this._popup = createPopUp(

--- a/demo/UIExamples.js
+++ b/demo/UIExamples.js
@@ -55,6 +55,10 @@ class MathEditorExample extends React.PureComponent<any, any, any> {
     );
   }
 
+  componentDidMount() {
+    setTimeout(this._onClick, 100);
+  }
+
   _onClick = (): void => {
     if (!this._popup) {
       this._popup = createPopUp(

--- a/dist/ui/mathquill-editor/MathQuillEditor.js
+++ b/dist/ui/mathquill-editor/MathQuillEditor.js
@@ -197,7 +197,7 @@ var MathQuillEditor = function (_React$PureComponent) {
     value: function render() {
       var value = this.props.value;
 
-      var panels = [MathQuillEditorSymbols.OPERATORS, MathQuillEditorSymbols.STRUCTURE, MathQuillEditorSymbols.SYMBOLS, MathQuillEditorSymbols.TRIG, MathQuillEditorSymbols.VARIABLES].map(this._renderPanel);
+      var panels = [MathQuillEditorSymbols.OPERATORS, MathQuillEditorSymbols.STRUCTURE, MathQuillEditorSymbols.SYMBOLS, MathQuillEditorSymbols.TRIG].map(this._renderPanel);
 
       var empty = !value;
       var className = (0, _classnames2.default)('czi-mathquill-editor', { empty: empty });

--- a/dist/ui/mathquill-editor/MathQuillEditor.js.flow
+++ b/dist/ui/mathquill-editor/MathQuillEditor.js.flow
@@ -64,7 +64,6 @@ class MathQuillEditor extends React.PureComponent<any, any, any> {
       MathQuillEditorSymbols.STRUCTURE,
       MathQuillEditorSymbols.SYMBOLS,
       MathQuillEditorSymbols.TRIG,
-      MathQuillEditorSymbols.VARIABLES,
     ].map(this._renderPanel);
 
     const empty = !value;

--- a/dist/ui/mathquill-editor/MathQuillEditorSymbols.js
+++ b/dist/ui/mathquill-editor/MathQuillEditorSymbols.js
@@ -282,6 +282,12 @@ var SIN = exports.SIN = {
   description: 'Sin',
   cmd: 'write'
 };
+var SMALLE = exports.SMALLE = {
+  label: '\u212F',
+  latex: '\u212F',
+  description: 'Script Small E',
+  cmd: 'write'
+};
 var SQR = exports.SQR = {
   label: 'x^{2}',
   latex: '^{2}',
@@ -396,7 +402,7 @@ var STRUCTURE = exports.STRUCTURE = {
 
 var SYMBOLS = exports.SYMBOLS = {
   title: 'Symbols',
-  symbols: [ANGLE, PI, IMAGINARY, DEGREES, THETA, PHI, TRIANGLE, INFINITY, DOLLAR, CENT, VDASH, PERP, ARROWLL, ARROWRL, ARROWLLR]
+  symbols: [SMALLE, ANGLE, PI, IMAGINARY, DEGREES, THETA, PHI, TRIANGLE, INFINITY, DOLLAR, CENT, VDASH, PERP, ARROWLL, ARROWRL, ARROWLLR]
 };
 
 var TRIG = exports.TRIG = {

--- a/dist/ui/mathquill-editor/MathQuillEditorSymbols.js
+++ b/dist/ui/mathquill-editor/MathQuillEditorSymbols.js
@@ -3,12 +3,6 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-
-
-// https://github.com/mathquill/mathquill/blob/23a0e88c80c79514ffc30ead490bd880306bce2a/src/commands/math/basicSymbols.js
-// http://math.chapman.edu/~jipsen/mathquill/test/MathQuillsymbolsMathJax.html
-// https://inspera.atlassian.net/wiki/spaces/KB/pages/62062830/MathQuill+symbols
-
 if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_MathQuillEditorSymbol', {
   value: require('prop-types').shape({
     label: require('prop-types').string.isRequired,
@@ -17,215 +11,395 @@ if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginF
     cmd: require('prop-types').string.isRequired
   })
 });
-var ABSOLUTE = {
+
+
+// It's hard to find a full list of latex symbols that we could use.
+// Here's are some references that might be helpful.
+// https://github.com/mathquill/mathquill/blob/23a0e88c80c79514ffc30ead490bd880306bce2a/src/commands/math/basicSymbols.js
+// http://math.chapman.edu/~jipsen/mathquill/test/MathQuillsymbolsMathJax.html
+// https://inspera.atlassian.net/wiki/spaces/KB/pages/62062830/MathQuill+symbols
+// https://www.rapidtables.com/math/symbols/Basic_Math_Symbols.html
+// https://www.math.uci.edu/~xiangwen/pdf/LaTeX-Math-Symbols.pdf
+
+if (typeof exports !== 'undefined') Object.defineProperty(exports, 'babelPluginFlowReactPropTypes_proptype_SymbolDefination', {
+  value: require('prop-types').shape({
+    label: require('prop-types').string.isRequired,
+    latex: require('prop-types').string.isRequired,
+    cmd: require('prop-types').oneOf(['cmd', 'write']).isRequired,
+    description: require('prop-types').string.isRequired
+  })
+});
+var ABSOLUTE = exports.ABSOLUTE = {
   label: '|x|',
   latex: '|',
   description: 'Absolute Value',
   cmd: 'cmd'
 };
-var ANGLE = {
+var ANGLE = exports.ANGLE = {
   label: '\\angle',
   latex: '\\angle',
   description: 'Angle',
   cmd: 'write'
 };
-var APPROX = {
+var APPROX = exports.APPROX = {
   label: '\\approx',
   latex: '\\approx',
-  description: 'Approx',
+  description: 'Approximation',
   cmd: 'cmd'
 };
-var ARCCOS = {
+var ARCCOS = exports.ARCCOS = {
   label: '\\arccos',
   latex: '\\arccos',
   description: 'Arc Cos',
   cmd: 'write'
 };
-var ARCSIN = {
+var ARCSIN = exports.ARCSIN = {
   label: '\\arcsin',
   latex: '\\arcsin',
   description: 'Arc Sin',
   cmd: 'write'
 };
-var ARCTAN = {
+var ARCTAN = exports.ARCTAN = {
   label: '\\arctan',
   latex: '\\arctan',
   description: 'Arc Tan',
   cmd: 'write'
 };
-var BRACKETS = {
+var ARROWLL = exports.ARROWLL = {
+  label: '\\Longleftarrow',
+  latex: '\\Longleftarrow',
+  description: 'Long Left Arrow',
+  cmd: 'write'
+};
+var ARROWRL = exports.ARROWRL = {
+  label: '\\Longrightarrow',
+  latex: '\\Longrightarrow',
+  description: 'Long Right Arrow',
+  cmd: 'write'
+};
+var ARROWLLR = exports.ARROWLLR = {
+  label: '\\Longleftrightarrow',
+  latex: '\\Longleftrightarrow',
+  description: 'Long Left Right Arrow',
+  cmd: 'write'
+};
+var BRACKETS = exports.BRACKETS = {
   label: '[x]',
   latex: '[',
   description: 'Brackets',
   cmd: 'cmd'
 };
-var CENT = { label: '¢', latex: '¢', description: 'Cent', cmd: 'write' };
-var COS = { label: '\\cos', latex: '\\cos', description: 'Cos', cmd: 'write' };
-var DEGREES = {
+var CENT = exports.CENT = { label: '¢', latex: '¢', description: 'Cent', cmd: 'write' };
+var COS = exports.COS = {
+  label: '\\cos',
+  latex: '\\cos',
+  description: 'Cos',
+  cmd: 'write'
+};
+var CONG = exports.CONG = {
+  label: '\\cong',
+  latex: '\\cong',
+  description: 'Congruent To',
+  cmd: 'write'
+};
+var CTIMES = exports.CTIMES = {
+  label: '\\otimes',
+  latex: '\\otimes',
+  description: 'Tensor Product',
+  cmd: 'write'
+};
+
+var DEGREES = exports.DEGREES = {
   label: '\\deg',
   latex: '\\deg',
   description: 'Degrees',
   cmd: 'write'
 };
-var DIVIDE = {
+var DIVIDE = exports.DIVIDE = {
   label: '\xF7',
   latex: '\\divide',
   description: 'Division',
   cmd: 'cmd'
 };
-var DOLLAR = { label: '$', latex: '$', description: 'Dollar', cmd: 'write' };
-var EQUAL = { label: '=', latex: '=', description: 'Equal', cmd: 'cmd' };
-var EXPONENT = {
-  label: 'x^{2}',
-  latex: '^{2}',
-  description: 'Exponent',
+var DOLLAR = exports.DOLLAR = {
+  label: '$',
+  latex: '$',
+  description: 'Dollar',
   cmd: 'write'
 };
-var FRAC = {
+
+var DOTM = exports.DOTM = {
+  label: '\\cdot',
+  latex: '\\cdot',
+  description: 'Dot for Multiplication',
+  cmd: 'write'
+};
+
+var EQUAL = exports.EQUAL = { label: '=', latex: '=', description: 'Equal', cmd: 'cmd' };
+var FRAC = exports.FRAC = {
   label: '\\frac {x}{y}',
   latex: '\\frac',
   description: 'Fraction',
   cmd: 'cmd'
 };
-var GT = { label: '>', latex: '>', description: 'Greater Than', cmd: 'cmd' };
-var GTE = {
+var GT = exports.GT = {
+  label: '>',
+  latex: '>',
+  description: 'Greater Than',
+  cmd: 'cmd'
+};
+var GTE = exports.GTE = {
   label: '\\ge',
   latex: '\\ge',
   description: 'Greater Than or Equal To',
   cmd: 'cmd'
 };
-var IMAGINARY = {
+var IMAGINARY = exports.IMAGINARY = {
   label: 'i',
   latex: 'i',
   description: 'Imaginary Number',
   cmd: 'write'
 };
-var INFINITY = {
+var INFINITY = exports.INFINITY = {
   label: '\\infty',
   latex: '\\infty',
   description: 'Infinity',
   cmd: 'write'
 };
-var INT = {
+var INT = exports.INT = {
   label: '\\int',
   latex: '\\int',
   description: 'Integral',
   cmd: 'cmd'
 };
-var INT01 = {
-  label: '\\int_{0}^{1}',
-  latex: '\\int_{0}^{1}',
+var INTERSECT = exports.INTERSECT = {
+  label: '\\cap',
+  latex: '\\cap',
+  description: 'Intersection',
+  cmd: 'write'
+};
+var INTXY = exports.INTXY = {
+  label: '\\int_{x}^{y}',
+  latex: '\\int_{x}^{y}',
   description: 'Integral',
   cmd: 'write'
 };
-var LT = { label: '<', latex: '<', description: 'Less Than', cmd: 'cmd' };
-var LTE = {
+var LOG_E = exports.LOG_E = {
+  label: '\\log',
+  latex: '\\log',
+  description: 'Log',
+  cmd: 'cmd'
+};
+var LT = exports.LT = {
+  label: '<',
+  latex: '<',
+  description: 'Less Than',
+  cmd: 'cmd'
+};
+var LTE = exports.LTE = {
   label: '\\le',
   latex: 'le',
   description: 'Less Than or Equal To',
   cmd: 'cmd'
 };
-var MINUS = { label: '-', latex: '-', description: 'Subtraction', cmd: 'cmd' };
-var OVERLINE = {
-  label: '\\overline{over}',
-  latex: '\\overline{over}',
-  description: 'Overline',
+var MINUS = exports.MINUS = {
+  label: '-',
+  latex: '-',
+  description: 'Subtraction',
+  cmd: 'cmd'
+};
+
+var NEQ = exports.NEQ = {
+  label: '\\neq',
+  latex: '\\neq',
+  description: 'Not Equal',
   cmd: 'write'
 };
-var PARENS = {
+
+var OVERLINE = exports.OVERLINE = {
+  label: '\\overline\u3000',
+  latex: '\\overline',
+  description: 'Overline',
+  cmd: 'cmd'
+};
+var PARENS = exports.PARENS = {
   label: '(x)',
   latex: '(',
   description: 'Parentheses',
   cmd: 'cmd'
 };
-var PHI = { label: '\\phi', latex: '\\phi', description: 'Phi', cmd: 'write' };
-var PI = { label: '\\pi', latex: '\\pi', description: 'Pi', cmd: 'write' };
-var PLUS = { label: '+', latex: '+', description: 'Addition', cmd: 'cmd' };
-var PM = {
+var PERP = exports.PERP = {
+  label: '\\perp',
+  latex: '\\perp',
+  description: 'Perpendicular Lines',
+  cmd: 'write'
+};
+var PHI = exports.PHI = {
+  label: '\\phi',
+  latex: '\\phi',
+  description: 'Phi',
+  cmd: 'write'
+};
+var PI = exports.PI = {
+  label: '\\pi',
+  latex: '\\pi',
+  description: 'Pi',
+  cmd: 'write'
+};
+var PLUS = exports.PLUS = {
+  label: '+',
+  latex: '+',
+  description: 'Addition',
+  cmd: 'cmd'
+};
+var PM = exports.PM = {
   label: '\\pm',
   latex: '\\pm',
   description: 'Plus-Minus',
   cmd: 'cmd'
 };
-var SIN = { label: '\\sin', latex: '\\sin', description: 'Sin', cmd: 'write' };
-var SQRT2 = {
+var POWER = exports.POWER = {
+  label: 'x^{y}',
+  latex: '^',
+  description: 'Power',
+  cmd: 'cmd'
+};
+var SIMEQ = exports.SIMEQ = {
+  label: '\\simeq',
+  latex: '\\simeq',
+  description: 'Approximately Equal',
+  cmd: 'write'
+};
+var SIM = exports.SIM = {
+  label: '\\sim',
+  latex: '\\sim',
+  description: 'Similarity',
+  cmd: 'write'
+};
+var SIN = exports.SIN = {
+  label: '\\sin',
+  latex: '\\sin',
+  description: 'Sin',
+  cmd: 'write'
+};
+var SQR = exports.SQR = {
+  label: 'x^{2}',
+  latex: '^{2}',
+  description: 'Square',
+  cmd: 'write'
+};
+var SQRT2 = exports.SQRT2 = {
   label: '\\sqrt[x]{y}',
   latex: '\\sqrt[x]{y}',
   description: 'Square Root Alt',
   cmd: 'write'
 };
-var SQRT = {
+var SQRT = exports.SQRT = {
   label: '\\sqrt x',
   latex: '\\sqrt',
   description: 'Square Root',
   cmd: 'cmd'
 };
-var SUBSCRIPT = {
+var SUBSCRIPT = exports.SUBSCRIPT = {
   label: 'x_{2}',
   latex: '_{2}',
   description: 'Subscript',
   cmd: 'write'
 };
-var SUM = {
+var SUBSET = exports.SUBSET = {
+  label: '\\sub',
+  latex: '\\sub',
+  description: 'Subset',
+  cmd: 'write'
+};
+var SUBSETEQ = exports.SUBSETEQ = {
+  label: '\\sube',
+  latex: '\\sube',
+  description: 'Subset or Equal',
+  cmd: 'write'
+};
+var SUM = exports.SUM = {
   label: '\\sum',
   latex: '\\sum',
   description: 'Summation',
   cmd: 'cmd'
 };
-var SUPERSCRIPT = {
-  label: 'x^{super}',
-  latex: '^{super}',
-  description: 'Exponent',
+var SUPERSET = exports.SUPERSET = {
+  label: '\\supset',
+  latex: '\\supset',
+  description: 'Superset',
   cmd: 'write'
 };
-var TAN = { label: '\\tan', latex: '\\tan', description: 'Tan', cmd: 'write' };
-var THETA = {
+var SUPERSETEQ = exports.SUPERSETEQ = {
+  label: '\\supe',
+  latex: '\\supe',
+  description: 'Superset or Equal',
+  cmd: 'write'
+};
+var TAN = exports.TAN = {
+  label: '\\tan',
+  latex: '\\tan',
+  description: 'Tan',
+  cmd: 'write'
+};
+var THETA = exports.THETA = {
   label: '\\theta',
   latex: '\\theta',
   description: 'Theta',
   cmd: 'write'
 };
-var TIMES = {
+var TIMES = exports.TIMES = {
   label: '\\times',
   latex: '\\times',
   description: 'Multiplication',
   cmd: 'cmd'
 };
-var TRIANGLE = {
+var TRIANGLE = exports.TRIANGLE = {
   label: '\\bigtriangleup',
   latex: '\\bigtriangleup',
   description: 'Triangle',
   cmd: 'write'
 };
-var X = { label: 'x', latex: 'x', description: 'x', cmd: 'write' };
-var Y = { label: 'y', latex: 'y', description: 'y', cmd: 'write' };
-
+var UNDERLINE = exports.UNDERLINE = {
+  label: '\\underline\u3000',
+  latex: '\\underline',
+  description: 'Underline',
+  cmd: 'cmd'
+};
+var UNION = exports.UNION = {
+  label: '\\cup',
+  latex: '\\cup',
+  description: 'Union',
+  cmd: 'write'
+};
+var VDASH = exports.VDASH = {
+  label: '\\vdash',
+  latex: '\\vdash',
+  description: 'Vertical and Dash Line',
+  cmd: 'write'
+};
+var VERT = exports.VERT = {
+  label: '\\vert',
+  latex: '\\vert',
+  description: 'Vertical Line',
+  cmd: 'write'
+};
 var OPERATORS = exports.OPERATORS = {
   title: 'Operators',
-  symbols: [PLUS, MINUS, TIMES, DIVIDE, EQUAL, PM, LT, GT, LTE, GTE]
+  symbols: [PLUS, MINUS, TIMES, DOTM, DIVIDE, EQUAL, APPROX, SIM, SIMEQ, CONG, NEQ, PM, LT, GT, LTE, GTE, UNION, INTERSECT, SUBSET, SUBSETEQ, SUPERSET, SUPERSETEQ, VERT, CTIMES]
 };
 
 var STRUCTURE = exports.STRUCTURE = {
   title: 'Structure',
-  symbols: [SUM, FRAC, PARENS, BRACKETS, EXPONENT, SUBSCRIPT, ABSOLUTE, INT01]
+  symbols: [SUM, FRAC, PARENS, BRACKETS, SQR, SUBSCRIPT, ABSOLUTE, INTXY, OVERLINE, UNDERLINE, POWER, INT, SQRT, SQRT2, LOG_E]
 };
 
 var SYMBOLS = exports.SYMBOLS = {
   title: 'Symbols',
-  symbols: [PI, SQRT, SQRT2, IMAGINARY, DEGREES, THETA, PHI]
+  symbols: [ANGLE, PI, IMAGINARY, DEGREES, THETA, PHI, TRIANGLE, INFINITY, DOLLAR, CENT, VDASH, PERP, ARROWLL, ARROWRL, ARROWLLR]
 };
 
 var TRIG = exports.TRIG = {
   title: 'Trigonometry',
   symbols: [SIN, COS, TAN, ARCSIN, ARCCOS, ARCTAN]
-};
-
-var VARIABLES = exports.VARIABLES = {
-  title: 'Variables',
-  symbols: [X, Y]
-};
-
-var MISC = exports.MISC = {
-  title: 'Miscellaneous',
-  symbols: [ANGLE, APPROX, CENT, DOLLAR, INFINITY, INT, OVERLINE, SUPERSCRIPT, TRIANGLE]
 };

--- a/dist/ui/mathquill-editor/MathQuillEditorSymbols.js.flow
+++ b/dist/ui/mathquill-editor/MathQuillEditorSymbols.js.flow
@@ -7,229 +7,460 @@ export type MathQuillEditorSymbol = {
   cmd: string,
 };
 
+export type SymbolDefination = {
+  // The label shown at the command button.
+  label: string,
+  // The latex to use
+  latex: string,
+  // The mathquill command to perform.
+  // http://docs.mathquill.com/en/latest/Api_Methods/#writelatex_string
+  // "write": Write the given LaTeX at the current cursor position. If the
+  //   cursor does not have focus, writes to last position the cursor occupied
+  //   in the editable field.
+  // "cmd": Enter a LaTeX command at the current cursor position or with the
+  //   current selection. If the cursor does not have focus, it writes it to
+  //   last position the cursor occupied in the editable field.
+  cmd: 'cmd' | 'write',
+  // the description of the command.
+  description: string,
+};
+
+// It's hard to find a full list of latex symbols that we could use.
+// Here's are some references that might be helpful.
 // https://github.com/mathquill/mathquill/blob/23a0e88c80c79514ffc30ead490bd880306bce2a/src/commands/math/basicSymbols.js
 // http://math.chapman.edu/~jipsen/mathquill/test/MathQuillsymbolsMathJax.html
 // https://inspera.atlassian.net/wiki/spaces/KB/pages/62062830/MathQuill+symbols
+// https://www.rapidtables.com/math/symbols/Basic_Math_Symbols.html
+// https://www.math.uci.edu/~xiangwen/pdf/LaTeX-Math-Symbols.pdf
 
-const ABSOLUTE = {
+export const ABSOLUTE = {
   label: '|x|',
   latex: '|',
   description: 'Absolute Value',
   cmd: 'cmd',
 };
-const ANGLE = {
+export const ANGLE = {
   label: '\\angle',
   latex: '\\angle',
   description: 'Angle',
   cmd: 'write',
 };
-const APPROX = {
+export const APPROX = {
   label: '\\approx',
   latex: '\\approx',
-  description: 'Approx',
+  description: 'Approximation',
   cmd: 'cmd',
 };
-const ARCCOS = {
+export const ARCCOS = {
   label: '\\arccos',
   latex: '\\arccos',
   description: 'Arc Cos',
   cmd: 'write',
 };
-const ARCSIN = {
+export const ARCSIN = {
   label: '\\arcsin',
   latex: '\\arcsin',
   description: 'Arc Sin',
   cmd: 'write',
 };
-const ARCTAN = {
+export const ARCTAN = {
   label: '\\arctan',
   latex: '\\arctan',
   description: 'Arc Tan',
   cmd: 'write',
 };
-const BRACKETS = {
+export const ARROWLL = {
+  label: '\\Longleftarrow',
+  latex: '\\Longleftarrow',
+  description: 'Long Left Arrow',
+  cmd: 'write',
+};
+export const ARROWRL = {
+  label: '\\Longrightarrow',
+  latex: '\\Longrightarrow',
+  description: 'Long Right Arrow',
+  cmd: 'write',
+};
+export const ARROWLLR = {
+  label: '\\Longleftrightarrow',
+  latex: '\\Longleftrightarrow',
+  description: 'Long Left Right Arrow',
+  cmd: 'write',
+};
+export const BRACKETS = {
   label: '[x]',
   latex: '[',
   description: 'Brackets',
   cmd: 'cmd',
 };
-const CENT = {label: '¢', latex: '¢', description: 'Cent', cmd: 'write'};
-const COS = {label: '\\cos', latex: '\\cos', description: 'Cos', cmd: 'write'};
-const DEGREES = {
+export const CENT = {label: '¢', latex: '¢', description: 'Cent', cmd: 'write'};
+export const COS = {
+  label: '\\cos',
+  latex: '\\cos',
+  description: 'Cos',
+  cmd: 'write',
+};
+export const CONG = {
+  label: '\\cong',
+  latex: '\\cong',
+  description: 'Congruent To',
+  cmd: 'write',
+};
+export const CTIMES = {
+  label: '\\otimes',
+  latex: '\\otimes',
+  description: 'Tensor Product',
+  cmd: 'write',
+};
+
+export const DEGREES = {
   label: '\\deg',
   latex: '\\deg',
   description: 'Degrees',
   cmd: 'write',
 };
-const DIVIDE = {
+export const DIVIDE = {
   label: '\u00F7',
   latex: '\\divide',
   description: 'Division',
   cmd: 'cmd',
 };
-const DOLLAR = {label: '$', latex: '$', description: 'Dollar', cmd: 'write'};
-const EQUAL = {label: '=', latex: '=', description: 'Equal', cmd: 'cmd'};
-const EXPONENT = {
-  label: 'x^{2}',
-  latex: '^{2}',
-  description: 'Exponent',
+export const DOLLAR = {
+  label: '$',
+  latex: '$',
+  description: 'Dollar',
   cmd: 'write',
 };
-const FRAC = {
+
+export const DOTM = {
+  label: '\\cdot',
+  latex: '\\cdot',
+  description: 'Dot for Multiplication',
+  cmd: 'write',
+};
+
+export const EQUAL = {label: '=', latex: '=', description: 'Equal', cmd: 'cmd'};
+export const FRAC = {
   label: '\\frac {x}{y}',
   latex: '\\frac',
   description: 'Fraction',
   cmd: 'cmd',
 };
-const GT = {label: '>', latex: '>', description: 'Greater Than', cmd: 'cmd'};
-const GTE = {
+export const GT = {
+  label: '>',
+  latex: '>',
+  description: 'Greater Than',
+  cmd: 'cmd',
+};
+export const GTE = {
   label: '\\ge',
   latex: '\\ge',
   description: 'Greater Than or Equal To',
   cmd: 'cmd',
 };
-const IMAGINARY = {
+export const IMAGINARY = {
   label: 'i',
   latex: 'i',
   description: 'Imaginary Number',
   cmd: 'write',
 };
-const INFINITY = {
+export const INFINITY = {
   label: '\\infty',
   latex: '\\infty',
   description: 'Infinity',
   cmd: 'write',
 };
-const INT = {
+export const INT = {
   label: '\\int',
   latex: '\\int',
   description: 'Integral',
   cmd: 'cmd',
 };
-const INT01 = {
-  label: '\\int_{0}^{1}',
-  latex: '\\int_{0}^{1}',
+export const INTERSECT = {
+  label: '\\cap',
+  latex: '\\cap',
+  description: 'Intersection',
+  cmd: 'write',
+};
+export const INTXY = {
+  label: '\\int_{x}^{y}',
+  latex: '\\int_{x}^{y}',
   description: 'Integral',
   cmd: 'write',
 };
-const LT = {label: '<', latex: '<', description: 'Less Than', cmd: 'cmd'};
-const LTE = {
+export const LOG_E = {
+  label: '\\log',
+  latex: '\\log',
+  description: 'Log',
+  cmd: 'cmd',
+};
+export const LT = {
+  label: '<',
+  latex: '<',
+  description: 'Less Than',
+  cmd: 'cmd',
+};
+export const LTE = {
   label: '\\le',
   latex: 'le',
   description: 'Less Than or Equal To',
   cmd: 'cmd',
 };
-const MINUS = {label: '-', latex: '-', description: 'Subtraction', cmd: 'cmd'};
-const OVERLINE = {
-  label: '\\overline{over}',
-  latex: '\\overline{over}',
-  description: 'Overline',
+export const MINUS = {
+  label: '-',
+  latex: '-',
+  description: 'Subtraction',
+  cmd: 'cmd',
+};
+
+export const NEQ = {
+  label: '\\neq',
+  latex: '\\neq',
+  description: 'Not Equal',
   cmd: 'write',
 };
-const PARENS = {
+
+export const OVERLINE = {
+  label: '\\overline\u3000',
+  latex: '\\overline',
+  description: 'Overline',
+  cmd: 'cmd',
+};
+export const PARENS = {
   label: '(x)',
   latex: '(',
   description: 'Parentheses',
   cmd: 'cmd',
 };
-const PHI = {label: '\\phi', latex: '\\phi', description: 'Phi', cmd: 'write'};
-const PI = {label: '\\pi', latex: '\\pi', description: 'Pi', cmd: 'write'};
-const PLUS = {label: '+', latex: '+', description: 'Addition', cmd: 'cmd'};
-const PM = {
+export const PERP = {
+  label: '\\perp',
+  latex: '\\perp',
+  description: 'Perpendicular Lines',
+  cmd: 'write',
+};
+export const PHI = {
+  label: '\\phi',
+  latex: '\\phi',
+  description: 'Phi',
+  cmd: 'write',
+};
+export const PI = {
+  label: '\\pi',
+  latex: '\\pi',
+  description: 'Pi',
+  cmd: 'write',
+};
+export const PLUS = {
+  label: '+',
+  latex: '+',
+  description: 'Addition',
+  cmd: 'cmd',
+};
+export const PM = {
   label: '\\pm',
   latex: '\\pm',
   description: 'Plus-Minus',
   cmd: 'cmd',
 };
-const SIN = {label: '\\sin', latex: '\\sin', description: 'Sin', cmd: 'write'};
-const SQRT2 = {
+export const POWER = {
+  label: 'x^{y}',
+  latex: '^',
+  description: 'Power',
+  cmd: 'cmd',
+};
+export const SIMEQ = {
+  label: '\\simeq',
+  latex: '\\simeq',
+  description: 'Approximately Equal',
+  cmd: 'write',
+};
+export const SIM = {
+  label: '\\sim',
+  latex: '\\sim',
+  description: 'Similarity',
+  cmd: 'write',
+};
+export const SIN = {
+  label: '\\sin',
+  latex: '\\sin',
+  description: 'Sin',
+  cmd: 'write',
+};
+export const SQR = {
+  label: 'x^{2}',
+  latex: '^{2}',
+  description: 'Square',
+  cmd: 'write',
+};
+export const SQRT2 = {
   label: '\\sqrt[x]{y}',
   latex: '\\sqrt[x]{y}',
   description: 'Square Root Alt',
   cmd: 'write',
 };
-const SQRT = {
+export const SQRT = {
   label: '\\sqrt x',
   latex: '\\sqrt',
   description: 'Square Root',
   cmd: 'cmd',
 };
-const SUBSCRIPT = {
+export const SUBSCRIPT = {
   label: 'x_{2}',
   latex: '_{2}',
   description: 'Subscript',
   cmd: 'write',
 };
-const SUM = {
+export const SUBSET = {
+  label: '\\sub',
+  latex: '\\sub',
+  description: 'Subset',
+  cmd: 'write',
+};
+export const SUBSETEQ = {
+  label: '\\sube',
+  latex: '\\sube',
+  description: 'Subset or Equal',
+  cmd: 'write',
+};
+export const SUM = {
   label: '\\sum',
   latex: '\\sum',
   description: 'Summation',
   cmd: 'cmd',
 };
-const SUPERSCRIPT = {
-  label: 'x^{super}',
-  latex: '^{super}',
-  description: 'Exponent',
+export const SUPERSET = {
+  label: '\\supset',
+  latex: '\\supset',
+  description: 'Superset',
   cmd: 'write',
 };
-const TAN = {label: '\\tan', latex: '\\tan', description: 'Tan', cmd: 'write'};
-const THETA = {
+export const SUPERSETEQ = {
+  label: '\\supe',
+  latex: '\\supe',
+  description: 'Superset or Equal',
+  cmd: 'write',
+};
+export const TAN = {
+  label: '\\tan',
+  latex: '\\tan',
+  description: 'Tan',
+  cmd: 'write',
+};
+export const THETA = {
   label: '\\theta',
   latex: '\\theta',
   description: 'Theta',
   cmd: 'write',
 };
-const TIMES = {
+export const TIMES = {
   label: '\\times',
   latex: '\\times',
   description: 'Multiplication',
   cmd: 'cmd',
 };
-const TRIANGLE = {
+export const TRIANGLE = {
   label: '\\bigtriangleup',
   latex: '\\bigtriangleup',
   description: 'Triangle',
   cmd: 'write',
 };
-const X = {label: 'x', latex: 'x', description: 'x', cmd: 'write'};
-const Y = {label: 'y', latex: 'y', description: 'y', cmd: 'write'};
-
+export const UNDERLINE = {
+  label: '\\underline\u3000',
+  latex: '\\underline',
+  description: 'Underline',
+  cmd: 'cmd',
+};
+export const UNION = {
+  label: '\\cup',
+  latex: '\\cup',
+  description: 'Union',
+  cmd: 'write',
+};
+export const VDASH = {
+  label: '\\vdash',
+  latex: '\\vdash',
+  description: 'Vertical and Dash Line',
+  cmd: 'write',
+};
+export const VERT = {
+  label: '\\vert',
+  latex: '\\vert',
+  description: 'Vertical Line',
+  cmd: 'write',
+};
 export const OPERATORS = {
   title: 'Operators',
-  symbols: [PLUS, MINUS, TIMES, DIVIDE, EQUAL, PM, LT, GT, LTE, GTE],
+  symbols: [
+    PLUS,
+    MINUS,
+    TIMES,
+    DOTM,
+    DIVIDE,
+    EQUAL,
+    APPROX,
+    SIM,
+    SIMEQ,
+    CONG,
+    NEQ,
+    PM,
+    LT,
+    GT,
+    LTE,
+    GTE,
+    UNION,
+    INTERSECT,
+    SUBSET,
+    SUBSETEQ,
+    SUPERSET,
+    SUPERSETEQ,
+    VERT,
+    CTIMES,
+  ],
 };
 
 export const STRUCTURE = {
   title: 'Structure',
-  symbols: [SUM, FRAC, PARENS, BRACKETS, EXPONENT, SUBSCRIPT, ABSOLUTE, INT01],
+  symbols: [
+    SUM,
+    FRAC,
+    PARENS,
+    BRACKETS,
+    SQR,
+    SUBSCRIPT,
+    ABSOLUTE,
+    INTXY,
+    OVERLINE,
+    UNDERLINE,
+    POWER,
+    INT,
+    SQRT,
+    SQRT2,
+    LOG_E,
+  ],
 };
 
 export const SYMBOLS = {
   title: 'Symbols',
-  symbols: [PI, SQRT, SQRT2, IMAGINARY, DEGREES, THETA, PHI],
+  symbols: [
+    ANGLE,
+    PI,
+    IMAGINARY,
+    DEGREES,
+    THETA,
+    PHI,
+    TRIANGLE,
+    INFINITY,
+    DOLLAR,
+    CENT,
+    VDASH,
+    PERP,
+    ARROWLL,
+    ARROWRL,
+    ARROWLLR,
+  ],
 };
 
 export const TRIG = {
   title: 'Trigonometry',
   symbols: [SIN, COS, TAN, ARCSIN, ARCCOS, ARCTAN],
-};
-
-export const VARIABLES = {
-  title: 'Variables',
-  symbols: [X, Y],
-};
-
-export const MISC = {
-  title: 'Miscellaneous',
-  symbols: [
-    ANGLE,
-    APPROX,
-    CENT,
-    DOLLAR,
-    INFINITY,
-    INT,
-    OVERLINE,
-    SUPERSCRIPT,
-    TRIANGLE,
-  ],
 };

--- a/dist/ui/mathquill-editor/MathQuillEditorSymbols.js.flow
+++ b/dist/ui/mathquill-editor/MathQuillEditorSymbols.js.flow
@@ -286,6 +286,12 @@ export const SIN = {
   description: 'Sin',
   cmd: 'write',
 };
+export const SMALLE = {
+  label: '\u212F',
+  latex: '\u212F',
+  description: 'Script Small E',
+  cmd: 'write',
+};
 export const SQR = {
   label: 'x^{2}',
   latex: '^{2}',
@@ -442,6 +448,7 @@ export const STRUCTURE = {
 export const SYMBOLS = {
   title: 'Symbols',
   symbols: [
+    SMALLE,
     ANGLE,
     PI,
     IMAGINARY,

--- a/dist/ui/renderLaTeXAsHTML.js
+++ b/dist/ui/renderLaTeXAsHTML.js
@@ -32,7 +32,10 @@ var latexEl = document.createElement('div');
 
 var cached = {};
 
-var CSS_CDN_URL = '//cdnjs.cloudflare.com/ajax/libs/KaTeX/0.10.0/katex.min.css';
+// Use KatexVersion "0.10.1" to fix format issue.
+// See https://github.com/sailinglab/pgm-spring-2019/pull/30
+var CSS_CDN_URL = '//cdnjs.cloudflare.com/ajax/libs/KaTeX/0.10.1/katex.min.css';
+
 var CSS_FONT = 'KaTeX_Main';
 
 (0, _asyncToGenerator3.default)( /*#__PURE__*/_regenerator2.default.mark(function _callee() {

--- a/dist/ui/renderLaTeXAsHTML.js.flow
+++ b/dist/ui/renderLaTeXAsHTML.js.flow
@@ -7,8 +7,11 @@ import katex from 'katex';
 const latexEl: any = document.createElement('div');
 const cached: Object = {};
 
+// Use KatexVersion "0.10.1" to fix format issue.
+// See https://github.com/sailinglab/pgm-spring-2019/pull/30
 const CSS_CDN_URL =
-  '//cdnjs.cloudflare.com/ajax/libs/KaTeX/0.10.0/katex.min.css';
+  '//cdnjs.cloudflare.com/ajax/libs/KaTeX/0.10.1/katex.min.css';
+
 const CSS_FONT = 'KaTeX_Main';
 
 (async function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8233,9 +8233,9 @@
       }
     },
     "katex": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.10.0.tgz",
-      "integrity": "sha512-/WRvx+L1eVBrLwX7QzKU1dQuaGnE7E8hDvx3VWfZh9HbMiCfsKWJNnYZ0S8ZMDAfAyDSofdyXIrH/hujF1fYXg==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.10.1.tgz",
+      "integrity": "sha512-iZXZ2L8pEP7HXBLAaeWkdLxnoRQ8Fdks8IuIVt01tYb+D8e0em5JYgfe6J48wXsuEr512IRCN5Kvwb9FjZH6kg==",
       "requires": {
         "commander": "2.19.0"
       }

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "color": "3.0.0",
     "invariant": "2.2.4",
     "jquery": "2.2.1",
-    "katex": "0.10.0",
+    "katex": "0.10.1",
     "node-mathquill": "0.10.0",
     "nullthrows": "1.0.1",
     "prosemirror-commands": "1.0.7",

--- a/src/ui/mathquill-editor/MathQuillEditor.js
+++ b/src/ui/mathquill-editor/MathQuillEditor.js
@@ -64,7 +64,6 @@ class MathQuillEditor extends React.PureComponent<any, any, any> {
       MathQuillEditorSymbols.STRUCTURE,
       MathQuillEditorSymbols.SYMBOLS,
       MathQuillEditorSymbols.TRIG,
-      MathQuillEditorSymbols.VARIABLES,
     ].map(this._renderPanel);
 
     const empty = !value;

--- a/src/ui/mathquill-editor/MathQuillEditorSymbols.js
+++ b/src/ui/mathquill-editor/MathQuillEditorSymbols.js
@@ -7,229 +7,460 @@ export type MathQuillEditorSymbol = {
   cmd: string,
 };
 
+export type SymbolDefination = {
+  // The label shown at the command button.
+  label: string,
+  // The latex to use
+  latex: string,
+  // The mathquill command to perform.
+  // http://docs.mathquill.com/en/latest/Api_Methods/#writelatex_string
+  // "write": Write the given LaTeX at the current cursor position. If the
+  //   cursor does not have focus, writes to last position the cursor occupied
+  //   in the editable field.
+  // "cmd": Enter a LaTeX command at the current cursor position or with the
+  //   current selection. If the cursor does not have focus, it writes it to
+  //   last position the cursor occupied in the editable field.
+  cmd: 'cmd' | 'write',
+  // the description of the command.
+  description: string,
+};
+
+// It's hard to find a full list of latex symbols that we could use.
+// Here's are some references that might be helpful.
 // https://github.com/mathquill/mathquill/blob/23a0e88c80c79514ffc30ead490bd880306bce2a/src/commands/math/basicSymbols.js
 // http://math.chapman.edu/~jipsen/mathquill/test/MathQuillsymbolsMathJax.html
 // https://inspera.atlassian.net/wiki/spaces/KB/pages/62062830/MathQuill+symbols
+// https://www.rapidtables.com/math/symbols/Basic_Math_Symbols.html
+// https://www.math.uci.edu/~xiangwen/pdf/LaTeX-Math-Symbols.pdf
 
-const ABSOLUTE = {
+export const ABSOLUTE = {
   label: '|x|',
   latex: '|',
   description: 'Absolute Value',
   cmd: 'cmd',
 };
-const ANGLE = {
+export const ANGLE = {
   label: '\\angle',
   latex: '\\angle',
   description: 'Angle',
   cmd: 'write',
 };
-const APPROX = {
+export const APPROX = {
   label: '\\approx',
   latex: '\\approx',
-  description: 'Approx',
+  description: 'Approximation',
   cmd: 'cmd',
 };
-const ARCCOS = {
+export const ARCCOS = {
   label: '\\arccos',
   latex: '\\arccos',
   description: 'Arc Cos',
   cmd: 'write',
 };
-const ARCSIN = {
+export const ARCSIN = {
   label: '\\arcsin',
   latex: '\\arcsin',
   description: 'Arc Sin',
   cmd: 'write',
 };
-const ARCTAN = {
+export const ARCTAN = {
   label: '\\arctan',
   latex: '\\arctan',
   description: 'Arc Tan',
   cmd: 'write',
 };
-const BRACKETS = {
+export const ARROWLL = {
+  label: '\\Longleftarrow',
+  latex: '\\Longleftarrow',
+  description: 'Long Left Arrow',
+  cmd: 'write',
+};
+export const ARROWRL = {
+  label: '\\Longrightarrow',
+  latex: '\\Longrightarrow',
+  description: 'Long Right Arrow',
+  cmd: 'write',
+};
+export const ARROWLLR = {
+  label: '\\Longleftrightarrow',
+  latex: '\\Longleftrightarrow',
+  description: 'Long Left Right Arrow',
+  cmd: 'write',
+};
+export const BRACKETS = {
   label: '[x]',
   latex: '[',
   description: 'Brackets',
   cmd: 'cmd',
 };
-const CENT = {label: '¢', latex: '¢', description: 'Cent', cmd: 'write'};
-const COS = {label: '\\cos', latex: '\\cos', description: 'Cos', cmd: 'write'};
-const DEGREES = {
+export const CENT = {label: '¢', latex: '¢', description: 'Cent', cmd: 'write'};
+export const COS = {
+  label: '\\cos',
+  latex: '\\cos',
+  description: 'Cos',
+  cmd: 'write',
+};
+export const CONG = {
+  label: '\\cong',
+  latex: '\\cong',
+  description: 'Congruent To',
+  cmd: 'write',
+};
+export const CTIMES = {
+  label: '\\otimes',
+  latex: '\\otimes',
+  description: 'Tensor Product',
+  cmd: 'write',
+};
+
+export const DEGREES = {
   label: '\\deg',
   latex: '\\deg',
   description: 'Degrees',
   cmd: 'write',
 };
-const DIVIDE = {
+export const DIVIDE = {
   label: '\u00F7',
   latex: '\\divide',
   description: 'Division',
   cmd: 'cmd',
 };
-const DOLLAR = {label: '$', latex: '$', description: 'Dollar', cmd: 'write'};
-const EQUAL = {label: '=', latex: '=', description: 'Equal', cmd: 'cmd'};
-const EXPONENT = {
-  label: 'x^{2}',
-  latex: '^{2}',
-  description: 'Exponent',
+export const DOLLAR = {
+  label: '$',
+  latex: '$',
+  description: 'Dollar',
   cmd: 'write',
 };
-const FRAC = {
+
+export const DOTM = {
+  label: '\\cdot',
+  latex: '\\cdot',
+  description: 'Dot for Multiplication',
+  cmd: 'write',
+};
+
+export const EQUAL = {label: '=', latex: '=', description: 'Equal', cmd: 'cmd'};
+export const FRAC = {
   label: '\\frac {x}{y}',
   latex: '\\frac',
   description: 'Fraction',
   cmd: 'cmd',
 };
-const GT = {label: '>', latex: '>', description: 'Greater Than', cmd: 'cmd'};
-const GTE = {
+export const GT = {
+  label: '>',
+  latex: '>',
+  description: 'Greater Than',
+  cmd: 'cmd',
+};
+export const GTE = {
   label: '\\ge',
   latex: '\\ge',
   description: 'Greater Than or Equal To',
   cmd: 'cmd',
 };
-const IMAGINARY = {
+export const IMAGINARY = {
   label: 'i',
   latex: 'i',
   description: 'Imaginary Number',
   cmd: 'write',
 };
-const INFINITY = {
+export const INFINITY = {
   label: '\\infty',
   latex: '\\infty',
   description: 'Infinity',
   cmd: 'write',
 };
-const INT = {
+export const INT = {
   label: '\\int',
   latex: '\\int',
   description: 'Integral',
   cmd: 'cmd',
 };
-const INT01 = {
-  label: '\\int_{0}^{1}',
-  latex: '\\int_{0}^{1}',
+export const INTERSECT = {
+  label: '\\cap',
+  latex: '\\cap',
+  description: 'Intersection',
+  cmd: 'write',
+};
+export const INTXY = {
+  label: '\\int_{x}^{y}',
+  latex: '\\int_{x}^{y}',
   description: 'Integral',
   cmd: 'write',
 };
-const LT = {label: '<', latex: '<', description: 'Less Than', cmd: 'cmd'};
-const LTE = {
+export const LOG_E = {
+  label: '\\log',
+  latex: '\\log',
+  description: 'Log',
+  cmd: 'cmd',
+};
+export const LT = {
+  label: '<',
+  latex: '<',
+  description: 'Less Than',
+  cmd: 'cmd',
+};
+export const LTE = {
   label: '\\le',
   latex: 'le',
   description: 'Less Than or Equal To',
   cmd: 'cmd',
 };
-const MINUS = {label: '-', latex: '-', description: 'Subtraction', cmd: 'cmd'};
-const OVERLINE = {
-  label: '\\overline{over}',
-  latex: '\\overline{over}',
-  description: 'Overline',
+export const MINUS = {
+  label: '-',
+  latex: '-',
+  description: 'Subtraction',
+  cmd: 'cmd',
+};
+
+export const NEQ = {
+  label: '\\neq',
+  latex: '\\neq',
+  description: 'Not Equal',
   cmd: 'write',
 };
-const PARENS = {
+
+export const OVERLINE = {
+  label: '\\overline\u3000',
+  latex: '\\overline',
+  description: 'Overline',
+  cmd: 'cmd',
+};
+export const PARENS = {
   label: '(x)',
   latex: '(',
   description: 'Parentheses',
   cmd: 'cmd',
 };
-const PHI = {label: '\\phi', latex: '\\phi', description: 'Phi', cmd: 'write'};
-const PI = {label: '\\pi', latex: '\\pi', description: 'Pi', cmd: 'write'};
-const PLUS = {label: '+', latex: '+', description: 'Addition', cmd: 'cmd'};
-const PM = {
+export const PERP = {
+  label: '\\perp',
+  latex: '\\perp',
+  description: 'Perpendicular Lines',
+  cmd: 'write',
+};
+export const PHI = {
+  label: '\\phi',
+  latex: '\\phi',
+  description: 'Phi',
+  cmd: 'write',
+};
+export const PI = {
+  label: '\\pi',
+  latex: '\\pi',
+  description: 'Pi',
+  cmd: 'write',
+};
+export const PLUS = {
+  label: '+',
+  latex: '+',
+  description: 'Addition',
+  cmd: 'cmd',
+};
+export const PM = {
   label: '\\pm',
   latex: '\\pm',
   description: 'Plus-Minus',
   cmd: 'cmd',
 };
-const SIN = {label: '\\sin', latex: '\\sin', description: 'Sin', cmd: 'write'};
-const SQRT2 = {
+export const POWER = {
+  label: 'x^{y}',
+  latex: '^',
+  description: 'Power',
+  cmd: 'cmd',
+};
+export const SIMEQ = {
+  label: '\\simeq',
+  latex: '\\simeq',
+  description: 'Approximately Equal',
+  cmd: 'write',
+};
+export const SIM = {
+  label: '\\sim',
+  latex: '\\sim',
+  description: 'Similarity',
+  cmd: 'write',
+};
+export const SIN = {
+  label: '\\sin',
+  latex: '\\sin',
+  description: 'Sin',
+  cmd: 'write',
+};
+export const SQR = {
+  label: 'x^{2}',
+  latex: '^{2}',
+  description: 'Square',
+  cmd: 'write',
+};
+export const SQRT2 = {
   label: '\\sqrt[x]{y}',
   latex: '\\sqrt[x]{y}',
   description: 'Square Root Alt',
   cmd: 'write',
 };
-const SQRT = {
+export const SQRT = {
   label: '\\sqrt x',
   latex: '\\sqrt',
   description: 'Square Root',
   cmd: 'cmd',
 };
-const SUBSCRIPT = {
+export const SUBSCRIPT = {
   label: 'x_{2}',
   latex: '_{2}',
   description: 'Subscript',
   cmd: 'write',
 };
-const SUM = {
+export const SUBSET = {
+  label: '\\sub',
+  latex: '\\sub',
+  description: 'Subset',
+  cmd: 'write',
+};
+export const SUBSETEQ = {
+  label: '\\sube',
+  latex: '\\sube',
+  description: 'Subset or Equal',
+  cmd: 'write',
+};
+export const SUM = {
   label: '\\sum',
   latex: '\\sum',
   description: 'Summation',
   cmd: 'cmd',
 };
-const SUPERSCRIPT = {
-  label: 'x^{super}',
-  latex: '^{super}',
-  description: 'Exponent',
+export const SUPERSET = {
+  label: '\\supset',
+  latex: '\\supset',
+  description: 'Superset',
   cmd: 'write',
 };
-const TAN = {label: '\\tan', latex: '\\tan', description: 'Tan', cmd: 'write'};
-const THETA = {
+export const SUPERSETEQ = {
+  label: '\\supe',
+  latex: '\\supe',
+  description: 'Superset or Equal',
+  cmd: 'write',
+};
+export const TAN = {
+  label: '\\tan',
+  latex: '\\tan',
+  description: 'Tan',
+  cmd: 'write',
+};
+export const THETA = {
   label: '\\theta',
   latex: '\\theta',
   description: 'Theta',
   cmd: 'write',
 };
-const TIMES = {
+export const TIMES = {
   label: '\\times',
   latex: '\\times',
   description: 'Multiplication',
   cmd: 'cmd',
 };
-const TRIANGLE = {
+export const TRIANGLE = {
   label: '\\bigtriangleup',
   latex: '\\bigtriangleup',
   description: 'Triangle',
   cmd: 'write',
 };
-const X = {label: 'x', latex: 'x', description: 'x', cmd: 'write'};
-const Y = {label: 'y', latex: 'y', description: 'y', cmd: 'write'};
-
+export const UNDERLINE = {
+  label: '\\underline\u3000',
+  latex: '\\underline',
+  description: 'Underline',
+  cmd: 'cmd',
+};
+export const UNION = {
+  label: '\\cup',
+  latex: '\\cup',
+  description: 'Union',
+  cmd: 'write',
+};
+export const VDASH = {
+  label: '\\vdash',
+  latex: '\\vdash',
+  description: 'Vertical and Dash Line',
+  cmd: 'write',
+};
+export const VERT = {
+  label: '\\vert',
+  latex: '\\vert',
+  description: 'Vertical Line',
+  cmd: 'write',
+};
 export const OPERATORS = {
   title: 'Operators',
-  symbols: [PLUS, MINUS, TIMES, DIVIDE, EQUAL, PM, LT, GT, LTE, GTE],
+  symbols: [
+    PLUS,
+    MINUS,
+    TIMES,
+    DOTM,
+    DIVIDE,
+    EQUAL,
+    APPROX,
+    SIM,
+    SIMEQ,
+    CONG,
+    NEQ,
+    PM,
+    LT,
+    GT,
+    LTE,
+    GTE,
+    UNION,
+    INTERSECT,
+    SUBSET,
+    SUBSETEQ,
+    SUPERSET,
+    SUPERSETEQ,
+    VERT,
+    CTIMES,
+  ],
 };
 
 export const STRUCTURE = {
   title: 'Structure',
-  symbols: [SUM, FRAC, PARENS, BRACKETS, EXPONENT, SUBSCRIPT, ABSOLUTE, INT01],
+  symbols: [
+    SUM,
+    FRAC,
+    PARENS,
+    BRACKETS,
+    SQR,
+    SUBSCRIPT,
+    ABSOLUTE,
+    INTXY,
+    OVERLINE,
+    UNDERLINE,
+    POWER,
+    INT,
+    SQRT,
+    SQRT2,
+    LOG_E,
+  ],
 };
 
 export const SYMBOLS = {
   title: 'Symbols',
-  symbols: [PI, SQRT, SQRT2, IMAGINARY, DEGREES, THETA, PHI],
+  symbols: [
+    ANGLE,
+    PI,
+    IMAGINARY,
+    DEGREES,
+    THETA,
+    PHI,
+    TRIANGLE,
+    INFINITY,
+    DOLLAR,
+    CENT,
+    VDASH,
+    PERP,
+    ARROWLL,
+    ARROWRL,
+    ARROWLLR,
+  ],
 };
 
 export const TRIG = {
   title: 'Trigonometry',
   symbols: [SIN, COS, TAN, ARCSIN, ARCCOS, ARCTAN],
-};
-
-export const VARIABLES = {
-  title: 'Variables',
-  symbols: [X, Y],
-};
-
-export const MISC = {
-  title: 'Miscellaneous',
-  symbols: [
-    ANGLE,
-    APPROX,
-    CENT,
-    DOLLAR,
-    INFINITY,
-    INT,
-    OVERLINE,
-    SUPERSCRIPT,
-    TRIANGLE,
-  ],
 };

--- a/src/ui/mathquill-editor/MathQuillEditorSymbols.js
+++ b/src/ui/mathquill-editor/MathQuillEditorSymbols.js
@@ -286,6 +286,12 @@ export const SIN = {
   description: 'Sin',
   cmd: 'write',
 };
+export const SMALLE = {
+  label: '\u212F',
+  latex: '\u212F',
+  description: 'Script Small E',
+  cmd: 'write',
+};
 export const SQR = {
   label: 'x^{2}',
   latex: '^{2}',
@@ -442,6 +448,7 @@ export const STRUCTURE = {
 export const SYMBOLS = {
   title: 'Symbols',
   symbols: [
+    SMALLE,
     ANGLE,
     PI,
     IMAGINARY,

--- a/src/ui/renderLaTeXAsHTML.js
+++ b/src/ui/renderLaTeXAsHTML.js
@@ -7,8 +7,11 @@ import katex from 'katex';
 const latexEl: any = document.createElement('div');
 const cached: Object = {};
 
+// Use KatexVersion "0.10.1" to fix format issue.
+// See https://github.com/sailinglab/pgm-spring-2019/pull/30
 const CSS_CDN_URL =
-  '//cdnjs.cloudflare.com/ajax/libs/KaTeX/0.10.0/katex.min.css';
+  '//cdnjs.cloudflare.com/ajax/libs/KaTeX/0.10.1/katex.min.css';
+
 const CSS_FONT = 'KaTeX_Main';
 
 (async function() {


### PR DESCRIPTION
Per request from users, we need to clean up some math symbols and add more symbols.
This diff updates the symbols used in math editor.

| before | after |
|---|---|
| ![image](https://user-images.githubusercontent.com/1504439/57163573-76677080-6da6-11e9-8f7a-84c2c9bfcc57.png) ![image](https://user-images.githubusercontent.com/1504439/57163625-939c3f00-6da6-11e9-917a-6b03fb725615.png) | ![image](https://user-images.githubusercontent.com/1504439/57163605-8717e680-6da6-11e9-8455-9109bccce384.png) ![image](https://user-images.githubusercontent.com/1504439/57163647-a151c480-6da6-11e9-98b2-b67cd6049bc4.png) | 
|---|---|
