### PR TITLE
Calibrate line-spacing value.

### DIFF
--- a/dist/ParagraphNodeSpec.js
+++ b/dist/ParagraphNodeSpec.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.getParagraphNodeAttrs = exports.toParagraphDOM = exports.EMPTY_CSS_VALUE = exports.LINE_SPACING_VALUES = exports.ATTRIBUTE_INDENT = exports.MAX_INDENT_LEVEL = exports.MIN_INDENT_LEVEL = exports.INDENT_MARGIN_PT_SIZE = undefined;
+exports.getParagraphNodeAttrs = exports.toParagraphDOM = exports.EMPTY_CSS_VALUE = exports.ATTRIBUTE_INDENT = exports.MAX_INDENT_LEVEL = exports.MIN_INDENT_LEVEL = exports.INDENT_MARGIN_PT_SIZE = undefined;
 
 var _set = require('babel-runtime/core-js/set');
 
@@ -11,15 +11,19 @@ var _set2 = _interopRequireDefault(_set);
 
 exports.convertMarginLeftToIndentValue = convertMarginLeftToIndentValue;
 
-var _prosemirrorModel = require('prosemirror-model');
+var _clamp = require('./ui/clamp');
+
+var _clamp2 = _interopRequireDefault(_clamp);
 
 var _convertToCSSPTValue = require('./convertToCSSPTValue');
 
 var _convertToCSSPTValue2 = _interopRequireDefault(_convertToCSSPTValue);
 
-var _clamp = require('./ui/clamp');
+var _toCSSLineSpacing = require('./ui/toCSSLineSpacing');
 
-var _clamp2 = _interopRequireDefault(_clamp);
+var _toCSSLineSpacing2 = _interopRequireDefault(_toCSSLineSpacing);
+
+var _prosemirrorModel = require('prosemirror-model');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -30,8 +34,6 @@ var INDENT_MARGIN_PT_SIZE = exports.INDENT_MARGIN_PT_SIZE = 36;
 var MIN_INDENT_LEVEL = exports.MIN_INDENT_LEVEL = 0;
 var MAX_INDENT_LEVEL = exports.MAX_INDENT_LEVEL = 7;
 var ATTRIBUTE_INDENT = exports.ATTRIBUTE_INDENT = 'data-indent';
-var LINE_SPACING_VALUES = exports.LINE_SPACING_VALUES = ['100%', '115%', '150%', // Default value.
-'200%'];
 
 var EMPTY_CSS_VALUE = exports.EMPTY_CSS_VALUE = new _set2.default(['', '0%', '0pt', '0px']);
 
@@ -78,7 +80,7 @@ function getAttrs(dom) {
 
   indent = indent || MIN_INDENT_LEVEL;
 
-  var lineSpacing = lineHeight ? lineHeight : null;
+  var lineSpacing = lineHeight ? (0, _toCSSLineSpacing2.default)(lineHeight) : null;
 
   var id = dom.getAttribute('id') || '';
   return { align: align, indent: indent, lineSpacing: lineSpacing, paddingTop: paddingTop, paddingBottom: paddingBottom, id: id };
@@ -101,7 +103,7 @@ function toDOM(node) {
   }
 
   if (lineSpacing) {
-    style += 'line-height: ' + lineSpacing + ';';
+    style += 'line-height: ' + (0, _toCSSLineSpacing2.default)(lineSpacing) + ';';
   }
 
   if (paddingTop && !EMPTY_CSS_VALUE.has(paddingTop)) {

--- a/dist/ParagraphNodeSpec.js.flow
+++ b/dist/ParagraphNodeSpec.js.flow
@@ -1,9 +1,9 @@
 // @flow
 
-import {Node} from 'prosemirror-model';
-
-import convertToCSSPTValue from './convertToCSSPTValue';
 import clamp from './ui/clamp';
+import convertToCSSPTValue from './convertToCSSPTValue';
+import toCSSLineSpacing from './ui/toCSSLineSpacing';
+import {Node} from 'prosemirror-model';
 
 import type {NodeSpec} from './Types';
 
@@ -12,12 +12,6 @@ export const INDENT_MARGIN_PT_SIZE = 36;
 export const MIN_INDENT_LEVEL = 0;
 export const MAX_INDENT_LEVEL = 7;
 export const ATTRIBUTE_INDENT = 'data-indent';
-export const LINE_SPACING_VALUES = [
-  '100%',
-  '115%',
-  '150%', // Default value.
-  '200%',
-];
 
 export const EMPTY_CSS_VALUE = new Set(['', '0%', '0pt', '0px']);
 
@@ -64,7 +58,7 @@ function getAttrs(dom: HTMLElement): Object {
 
   indent = indent || MIN_INDENT_LEVEL;
 
-  const lineSpacing = lineHeight ? lineHeight : null;
+  const lineSpacing = lineHeight ? toCSSLineSpacing(lineHeight) : null;
 
   const id = dom.getAttribute('id') || '';
   return {align, indent, lineSpacing, paddingTop, paddingBottom, id};
@@ -87,7 +81,7 @@ function toDOM(node: Node): Array<any> {
   }
 
   if (lineSpacing) {
-    style += `line-height: ${lineSpacing};`;
+    style += `line-height: ${toCSSLineSpacing(lineSpacing)};`;
   }
 
   if (paddingTop && !EMPTY_CSS_VALUE.has(paddingTop)) {

--- a/dist/TextLineSpacingCommand.js
+++ b/dist/TextLineSpacingCommand.js
@@ -26,21 +26,21 @@ var _extends3 = _interopRequireDefault(_extends2);
 
 exports.setTextLineSpacing = setTextLineSpacing;
 
-var _prosemirrorModel = require('prosemirror-model');
-
-var _prosemirrorState = require('prosemirror-state');
-
-var _prosemirrorTransform = require('prosemirror-transform');
-
-var _prosemirrorView = require('prosemirror-view');
-
-var _NodeNames = require('./NodeNames');
-
-var _ParagraphNodeSpec = require('./ParagraphNodeSpec');
-
 var _UICommand2 = require('./ui/UICommand');
 
 var _UICommand3 = _interopRequireDefault(_UICommand2);
+
+var _prosemirrorState = require('prosemirror-state');
+
+var _NodeNames = require('./NodeNames');
+
+var _prosemirrorView = require('prosemirror-view');
+
+var _prosemirrorModel = require('prosemirror-model');
+
+var _prosemirrorTransform = require('prosemirror-transform');
+
+var _toCSSLineSpacing = require('./ui/toCSSLineSpacing');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -113,12 +113,11 @@ function setTextLineSpacing(tr, schema, lineSpacing) {
 }
 
 function createGroup() {
-  var group = {};
-  group['Single'] = new TextLineSpacingCommand(null);
-  _ParagraphNodeSpec.LINE_SPACING_VALUES.forEach(function (lineSpacing) {
-    var label = lineSpacing === '200%' ? 'Double' : ' ' + lineSpacing + ' ';
-    group[label] = new TextLineSpacingCommand(lineSpacing);
-  });
+  var group = {
+    Single: new TextLineSpacingCommand(_toCSSLineSpacing.SINGLE_LINE_SPACING),
+    ' 150% ': new TextLineSpacingCommand('150%'),
+    Double: new TextLineSpacingCommand(_toCSSLineSpacing.DOUBLE_LINE_SPACING)
+  };
   return [group];
 }
 

--- a/dist/TextLineSpacingCommand.js.flow
+++ b/dist/TextLineSpacingCommand.js.flow
@@ -1,14 +1,13 @@
 // @flow
 
-import {Schema} from 'prosemirror-model';
-import {EditorState} from 'prosemirror-state';
-import {AllSelection, TextSelection} from 'prosemirror-state';
-import {Transform} from 'prosemirror-transform';
-import {EditorView} from 'prosemirror-view';
-
-import {BLOCKQUOTE, HEADING, LIST_ITEM, PARAGRAPH} from './NodeNames';
-import {LINE_SPACING_VALUES} from './ParagraphNodeSpec';
 import UICommand from './ui/UICommand';
+import {AllSelection, TextSelection} from 'prosemirror-state';
+import {BLOCKQUOTE, HEADING, LIST_ITEM, PARAGRAPH} from './NodeNames';
+import {EditorState} from 'prosemirror-state';
+import {EditorView} from 'prosemirror-view';
+import {Schema} from 'prosemirror-model';
+import {Transform} from 'prosemirror-transform';
+import {DOUBLE_LINE_SPACING, SINGLE_LINE_SPACING} from './ui/toCSSLineSpacing';
 
 export function setTextLineSpacing(
   tr: Transform,
@@ -85,12 +84,11 @@ export function setTextLineSpacing(
 }
 
 function createGroup(): Array<{[string]: TextLineSpacingCommand}> {
-  const group = {};
-  group['Single'] = new TextLineSpacingCommand(null);
-  LINE_SPACING_VALUES.forEach(lineSpacing => {
-    const label = lineSpacing === '200%' ? 'Double' : ` ${lineSpacing} `;
-    group[label] = new TextLineSpacingCommand(lineSpacing);
-  });
+  const group = {
+    Single: new TextLineSpacingCommand(SINGLE_LINE_SPACING),
+    ' 150% ': new TextLineSpacingCommand('150%'),
+    Double: new TextLineSpacingCommand(DOUBLE_LINE_SPACING),
+  };
   return [group];
 }
 

--- a/dist/patchStyleElements.js
+++ b/dist/patchStyleElements.js
@@ -23,9 +23,14 @@ var _toCSSColor = require('./ui/toCSSColor');
 
 var _toCSSColor2 = _interopRequireDefault(_toCSSColor);
 
+var _toCSSLineSpacing = require('./ui/toCSSLineSpacing');
+
+var _toCSSLineSpacing2 = _interopRequireDefault(_toCSSLineSpacing);
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var LIST_ITEM_PSEUDO_ELEMENT_BEFORE = /li:+before/;
+
 var NODE_NAME_SELECTOR = /^[a-zA-Z]+\d*$/;
 var PSEUDO_ELEMENT_ANY = /:+[a-z]+/;
 
@@ -74,19 +79,24 @@ function patchStyleElements(doc) {
       }
       var cssText = '';
       rule.styleMap.forEach(function (cssStyleValue, key) {
+        var cssStyleValueStr = String(cssStyleValue);
         // e.g. rules['color'] = 'red'.
         if (key === 'color') {
-          var color = (0, _toCSSColor2.default)(String(cssStyleValue));
+          var color = (0, _toCSSColor2.default)(cssStyleValueStr);
           if (!color) {
             return;
           }
         } else if (key === 'background-color') {
-          var _color = (0, _toCSSColor2.default)(String(cssStyleValue));
+          var _color = (0, _toCSSColor2.default)(cssStyleValueStr);
           if (!_color) {
             return;
           }
+        } else if (key === 'line-height') {
+          cssStyleValueStr = (0, _toCSSLineSpacing2.default)(cssStyleValueStr);
         }
-        cssText += key + ': ' + cssStyleValue + ';';
+        if (cssStyleValueStr) {
+          cssText += key + ': ' + cssStyleValueStr + ';';
+        }
       });
       if (selectorText.indexOf(',') > -1) {
         selectorText.split(/\s*,\s*/).forEach(function (st) {

--- a/dist/patchStyleElements.js.flow
+++ b/dist/patchStyleElements.js.flow
@@ -1,8 +1,8 @@
 // @flow
 
 import stable from 'stable';
-
 import toCSSColor from './ui/toCSSColor';
+import toCSSLineSpacing from './ui/toCSSLineSpacing';
 
 const LIST_ITEM_PSEUDO_ELEMENT_BEFORE = /li:+before/;
 const NODE_NAME_SELECTOR = /^[a-zA-Z]+\d*$/;
@@ -60,19 +60,24 @@ export default function patchStyleElements(doc: Document): void {
       }
       let cssText = '';
       rule.styleMap.forEach((cssStyleValue, key) => {
+        let cssStyleValueStr = String(cssStyleValue);
         // e.g. rules['color'] = 'red'.
         if (key === 'color') {
-          const color = toCSSColor(String(cssStyleValue));
+          const color = toCSSColor(cssStyleValueStr);
           if (!color) {
             return;
           }
         } else if (key === 'background-color') {
-          const color = toCSSColor(String(cssStyleValue));
+          const color = toCSSColor(cssStyleValueStr);
           if (!color) {
             return;
           }
+        } else if (key === 'line-height') {
+          cssStyleValueStr = toCSSLineSpacing(cssStyleValueStr);
         }
-        cssText += `${key}: ${cssStyleValue};`;
+        if (cssStyleValueStr) {
+          cssText += `${key}: ${cssStyleValueStr};`;
+        }
       });
       if (selectorText.indexOf(',') > -1) {
         selectorText.split(/\s*,\s*/).forEach(st => {

--- a/dist/ui/czi-vars.css
+++ b/dist/ui/czi-vars.css
@@ -2,7 +2,7 @@
   --czi-blockquote-background-color: rgba(0, 0, 0, 0.05);
   --czi-blockquote-border: solid 8px rgba(0, 0, 0, 0.6);
   --czi-blockquote-color: #555;
-  --czi-blockquote-font-family: "Open Sans";
+  --czi-blockquote-font-family: 'Open Sans';
   --czi-border-blue: solid 1px #5882eb;
   --czi-border-grey: solid 1px #ccc;
   --czi-border-red: solid 1px #f00;
@@ -37,6 +37,6 @@
   --czi-content-font-size-h2: 16px;
   --czi-content-font-size-h3: 13px;
   --czi-content-font-size: 11pt;
-  --czi-content-line-height: 1.5;
+  --czi-content-line-height: 1.25;
   --czi-content-link-color: rgb(0, 0, 238);
 }

--- a/dist/ui/toCSSLineSpacing.js
+++ b/dist/ui/toCSSLineSpacing.js
@@ -1,0 +1,47 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.DOUBLE_LINE_SPACING = exports.SINGLE_LINE_SPACING = undefined;
+
+var _set = require('babel-runtime/core-js/set');
+
+var _set2 = _interopRequireDefault(_set);
+
+exports.default = toCSSLineSpacing;
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var SINGLE_LINE_SPACING = exports.SINGLE_LINE_SPACING = '125%';
+var DOUBLE_LINE_SPACING = exports.DOUBLE_LINE_SPACING = '200%';
+
+// In Google Doc, "single line height" is exported as style
+// "line-height: 1.15" which is too narrow to read.
+// This defines the deprecate line spacing values that should me migrated.
+var DEPRECATED_SINGLE_LINE_SPACING_VALUES = new _set2.default(['115%', '100%']);
+
+var NUMBER_VALUE_PATTERN = /^\d+(.\d+)?$/;
+
+// Normalize the css line-height vlaue to percentage-based value if applicable.
+// e.g. This converts "1.5" to "150%".
+function toCSSLineSpacing(source) {
+  if (!source) {
+    return '';
+  }
+
+  var strValue = String(source);
+
+  // e.g. line-height: 1.5;
+  if (NUMBER_VALUE_PATTERN.test(strValue)) {
+    var numValue = parseFloat(strValue);
+    strValue = String(Math.round(numValue * 100)) + '%';
+  }
+
+  if (DEPRECATED_SINGLE_LINE_SPACING_VALUES.has(strValue)) {
+    return SINGLE_LINE_SPACING;
+  }
+
+  // e.g. line-height: 15px;
+  return strValue;
+}

--- a/dist/ui/toCSSLineSpacing.js.flow
+++ b/dist/ui/toCSSLineSpacing.js.flow
@@ -1,0 +1,34 @@
+// @flow
+
+export const SINGLE_LINE_SPACING = '125%';
+export const DOUBLE_LINE_SPACING = '200%';
+
+// In Google Doc, "single line height" is exported as style
+// "line-height: 1.15" which is too narrow to read.
+// This defines the deprecate line spacing values that should me migrated.
+const DEPRECATED_SINGLE_LINE_SPACING_VALUES = new Set(['115%', '100%']);
+
+const NUMBER_VALUE_PATTERN = /^\d+(.\d+)?$/;
+
+// Normalize the css line-height vlaue to percentage-based value if applicable.
+// e.g. This converts "1.5" to "150%".
+export default function toCSSLineSpacing(source: any): string {
+  if (!source) {
+    return '';
+  }
+
+  let strValue = String(source);
+
+  // e.g. line-height: 1.5;
+  if (NUMBER_VALUE_PATTERN.test(strValue)) {
+    const numValue = parseFloat(strValue);
+    strValue = String(Math.round(numValue * 100)) + '%';
+  }
+
+  if (DEPRECATED_SINGLE_LINE_SPACING_VALUES.has(strValue)) {
+    return SINGLE_LINE_SPACING;
+  }
+
+  // e.g. line-height: 15px;
+  return strValue;
+}

--- a/src/ParagraphNodeSpec.js
+++ b/src/ParagraphNodeSpec.js
@@ -1,9 +1,9 @@
 // @flow
 
-import {Node} from 'prosemirror-model';
-
-import convertToCSSPTValue from './convertToCSSPTValue';
 import clamp from './ui/clamp';
+import convertToCSSPTValue from './convertToCSSPTValue';
+import toCSSLineSpacing from './ui/toCSSLineSpacing';
+import {Node} from 'prosemirror-model';
 
 import type {NodeSpec} from './Types';
 
@@ -12,12 +12,6 @@ export const INDENT_MARGIN_PT_SIZE = 36;
 export const MIN_INDENT_LEVEL = 0;
 export const MAX_INDENT_LEVEL = 7;
 export const ATTRIBUTE_INDENT = 'data-indent';
-export const LINE_SPACING_VALUES = [
-  '100%',
-  '115%',
-  '150%', // Default value.
-  '200%',
-];
 
 export const EMPTY_CSS_VALUE = new Set(['', '0%', '0pt', '0px']);
 
@@ -64,7 +58,7 @@ function getAttrs(dom: HTMLElement): Object {
 
   indent = indent || MIN_INDENT_LEVEL;
 
-  const lineSpacing = lineHeight ? lineHeight : null;
+  const lineSpacing = lineHeight ? toCSSLineSpacing(lineHeight) : null;
 
   const id = dom.getAttribute('id') || '';
   return {align, indent, lineSpacing, paddingTop, paddingBottom, id};
@@ -87,7 +81,7 @@ function toDOM(node: Node): Array<any> {
   }
 
   if (lineSpacing) {
-    style += `line-height: ${lineSpacing};`;
+    style += `line-height: ${toCSSLineSpacing(lineSpacing)};`;
   }
 
   if (paddingTop && !EMPTY_CSS_VALUE.has(paddingTop)) {

--- a/src/TextLineSpacingCommand.js
+++ b/src/TextLineSpacingCommand.js
@@ -1,14 +1,13 @@
 // @flow
 
-import {Schema} from 'prosemirror-model';
-import {EditorState} from 'prosemirror-state';
-import {AllSelection, TextSelection} from 'prosemirror-state';
-import {Transform} from 'prosemirror-transform';
-import {EditorView} from 'prosemirror-view';
-
-import {BLOCKQUOTE, HEADING, LIST_ITEM, PARAGRAPH} from './NodeNames';
-import {LINE_SPACING_VALUES} from './ParagraphNodeSpec';
 import UICommand from './ui/UICommand';
+import {AllSelection, TextSelection} from 'prosemirror-state';
+import {BLOCKQUOTE, HEADING, LIST_ITEM, PARAGRAPH} from './NodeNames';
+import {EditorState} from 'prosemirror-state';
+import {EditorView} from 'prosemirror-view';
+import {Schema} from 'prosemirror-model';
+import {Transform} from 'prosemirror-transform';
+import {DOUBLE_LINE_SPACING, SINGLE_LINE_SPACING} from './ui/toCSSLineSpacing';
 
 export function setTextLineSpacing(
   tr: Transform,
@@ -85,12 +84,11 @@ export function setTextLineSpacing(
 }
 
 function createGroup(): Array<{[string]: TextLineSpacingCommand}> {
-  const group = {};
-  group['Single'] = new TextLineSpacingCommand(null);
-  LINE_SPACING_VALUES.forEach(lineSpacing => {
-    const label = lineSpacing === '200%' ? 'Double' : ` ${lineSpacing} `;
-    group[label] = new TextLineSpacingCommand(lineSpacing);
-  });
+  const group = {
+    Single: new TextLineSpacingCommand(SINGLE_LINE_SPACING),
+    ' 150% ': new TextLineSpacingCommand('150%'),
+    Double: new TextLineSpacingCommand(DOUBLE_LINE_SPACING),
+  };
   return [group];
 }
 

--- a/src/patchStyleElements.js
+++ b/src/patchStyleElements.js
@@ -1,8 +1,8 @@
 // @flow
 
 import stable from 'stable';
-
 import toCSSColor from './ui/toCSSColor';
+import toCSSLineSpacing from './ui/toCSSLineSpacing';
 
 const LIST_ITEM_PSEUDO_ELEMENT_BEFORE = /li:+before/;
 const NODE_NAME_SELECTOR = /^[a-zA-Z]+\d*$/;
@@ -60,19 +60,24 @@ export default function patchStyleElements(doc: Document): void {
       }
       let cssText = '';
       rule.styleMap.forEach((cssStyleValue, key) => {
+        let cssStyleValueStr = String(cssStyleValue);
         // e.g. rules['color'] = 'red'.
         if (key === 'color') {
-          const color = toCSSColor(String(cssStyleValue));
+          const color = toCSSColor(cssStyleValueStr);
           if (!color) {
             return;
           }
         } else if (key === 'background-color') {
-          const color = toCSSColor(String(cssStyleValue));
+          const color = toCSSColor(cssStyleValueStr);
           if (!color) {
             return;
           }
+        } else if (key === 'line-height') {
+          cssStyleValueStr = toCSSLineSpacing(cssStyleValueStr);
         }
-        cssText += `${key}: ${cssStyleValue};`;
+        if (cssStyleValueStr) {
+          cssText += `${key}: ${cssStyleValueStr};`;
+        }
       });
       if (selectorText.indexOf(',') > -1) {
         selectorText.split(/\s*,\s*/).forEach(st => {

--- a/src/ui/czi-vars.css
+++ b/src/ui/czi-vars.css
@@ -2,7 +2,7 @@
   --czi-blockquote-background-color: rgba(0, 0, 0, 0.05);
   --czi-blockquote-border: solid 8px rgba(0, 0, 0, 0.6);
   --czi-blockquote-color: #555;
-  --czi-blockquote-font-family: "Open Sans";
+  --czi-blockquote-font-family: 'Open Sans';
   --czi-border-blue: solid 1px #5882eb;
   --czi-border-grey: solid 1px #ccc;
   --czi-border-red: solid 1px #f00;
@@ -37,6 +37,6 @@
   --czi-content-font-size-h2: 16px;
   --czi-content-font-size-h3: 13px;
   --czi-content-font-size: 11pt;
-  --czi-content-line-height: 1.5;
+  --czi-content-line-height: 1.25;
   --czi-content-link-color: rgb(0, 0, 238);
 }

--- a/src/ui/toCSSLineSpacing.js
+++ b/src/ui/toCSSLineSpacing.js
@@ -1,0 +1,34 @@
+// @flow
+
+export const SINGLE_LINE_SPACING = '125%';
+export const DOUBLE_LINE_SPACING = '200%';
+
+// In Google Doc, "single line height" is exported as style
+// "line-height: 1.15" which is too narrow to read.
+// This defines the deprecate line spacing values that should me migrated.
+const DEPRECATED_SINGLE_LINE_SPACING_VALUES = new Set(['115%', '100%']);
+
+const NUMBER_VALUE_PATTERN = /^\d+(.\d+)?$/;
+
+// Normalize the css line-height vlaue to percentage-based value if applicable.
+// e.g. This converts "1.5" to "150%".
+export default function toCSSLineSpacing(source: any): string {
+  if (!source) {
+    return '';
+  }
+
+  let strValue = String(source);
+
+  // e.g. line-height: 1.5;
+  if (NUMBER_VALUE_PATTERN.test(strValue)) {
+    const numValue = parseFloat(strValue);
+    strValue = String(Math.round(numValue * 100)) + '%';
+  }
+
+  if (DEPRECATED_SINGLE_LINE_SPACING_VALUES.has(strValue)) {
+    return SINGLE_LINE_SPACING;
+  }
+
+  // e.g. line-height: 15px;
+  return strValue;
+}


### PR DESCRIPTION
The current value "1" that represents the "single line spacing" is too small for proper readability.
We should calibrate it and use "1.25" instead.

Also the, Google has been incorrectly exporting "1.15" for "single line spacing" while Google Doc itself uses "1.25" for "single line spacing" 

This PR calibrates the value that used to represents the  "single line spacing".

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/1504439/57491380-8208da80-7271-11e9-8d86-f9609e0eee18.png) | ![image](https://user-images.githubusercontent.com/1504439/57491406-9947c800-7271-11e9-845a-376d66d1b602.png)  |