### PR TITLE
[easy] Fix logics that detects cropped image.

### DIFF
--- a/dist/ImageNodeSpec.js
+++ b/dist/ImageNodeSpec.js
@@ -4,9 +4,16 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _set = require('babel-runtime/core-js/set');
+
+var _set2 = _interopRequireDefault(_set);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
 var babelPluginFlowReactPropTypes_proptype_NodeSpec = require('./Types').babelPluginFlowReactPropTypes_proptype_NodeSpec || require('prop-types').any;
 
 var CSS_ROTATE_PATTERN = /rotate\(([0-9\.]+)rad\)/i;
+var EMPTY_CSS_VALUE = new _set2.default(['0%', '0pt', '0px']);
 
 function getAttrs(dom) {
   var _dom$style = dom.style,
@@ -39,7 +46,7 @@ function getAttrs(dom) {
   if (parentElement instanceof HTMLElement) {
     // Special case for Google doc's image.
     var ps = parentElement.style;
-    if (ps.display === 'inline-block' && ps.overflow === 'hidden' && ps.width && ps.height && marginLeft && marginTop) {
+    if (ps.display === 'inline-block' && ps.overflow === 'hidden' && ps.width && ps.height && marginLeft && !EMPTY_CSS_VALUE.has(marginLeft) && marginTop && !EMPTY_CSS_VALUE.has(marginTop)) {
       crop = {
         width: parseInt(ps.width, 10) || 0,
         height: parseInt(ps.height, 10) || 0,

--- a/dist/ImageNodeSpec.js.flow
+++ b/dist/ImageNodeSpec.js.flow
@@ -3,6 +3,7 @@
 import type {NodeSpec} from './Types';
 
 const CSS_ROTATE_PATTERN = /rotate\(([0-9\.]+)rad\)/i;
+const EMPTY_CSS_VALUE = new Set(['0%', '0pt', '0px']);
 
 function getAttrs(dom: HTMLElement) {
   const {cssFloat, display, marginTop, marginLeft} = dom.style;
@@ -33,7 +34,9 @@ function getAttrs(dom: HTMLElement) {
       ps.width &&
       ps.height &&
       marginLeft &&
-      marginTop
+      !EMPTY_CSS_VALUE.has(marginLeft) &&
+      marginTop &&
+      !EMPTY_CSS_VALUE.has(marginTop)
     ) {
       crop = {
         width: parseInt(ps.width, 10) || 0,

--- a/src/ImageNodeSpec.js
+++ b/src/ImageNodeSpec.js
@@ -3,6 +3,7 @@
 import type {NodeSpec} from './Types';
 
 const CSS_ROTATE_PATTERN = /rotate\(([0-9\.]+)rad\)/i;
+const EMPTY_CSS_VALUE = new Set(['0%', '0pt', '0px']);
 
 function getAttrs(dom: HTMLElement) {
   const {cssFloat, display, marginTop, marginLeft} = dom.style;
@@ -33,7 +34,9 @@ function getAttrs(dom: HTMLElement) {
       ps.width &&
       ps.height &&
       marginLeft &&
-      marginTop
+      !EMPTY_CSS_VALUE.has(marginLeft) &&
+      marginTop &&
+      !EMPTY_CSS_VALUE.has(marginTop)
     ) {
       crop = {
         width: parseInt(ps.width, 10) || 0,


### PR DESCRIPTION
The logic that detects cropped image checks `marginLeft` and `marginTop`. If both `marginLeft` and `marginTop` are present, it thinks that the image is cropped.

However, to check whether `marginLeft` and `marginTop` are present, it should not only perform nullity check, it shall also check if the value means "empty" (e.g. "0px").

### Test Plan

- copy HTML from https://gist.github.com/hedgerwang/67845c04e0825bc08809b40607fb6ca6
- paste conversion in http://localhost:3001/convert.html
- verify that the images at the doc is resize-able.
