### PR TITLE
Update UI for navigating to a  bookmark.

### DIFF
--- a/dist/ui/LinkTooltip.js
+++ b/dist/ui/LinkTooltip.js
@@ -54,7 +54,7 @@ require('./czi-link-tooltip.css');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-function isBookmarHref(href) {
+function isBookMarkHref(href) {
   return !!href && href.indexOf('#') === 0 && href.length >= 2;
 }
 
@@ -76,7 +76,7 @@ var LinkTooltip = function (_React$PureComponent) {
     return _ret = (_temp = (_this = (0, _possibleConstructorReturn3.default)(this, (_ref = LinkTooltip.__proto__ || (0, _getPrototypeOf2.default)(LinkTooltip)).call.apply(_ref, [this].concat(args))), _this), _this._unmounted = false, _this.state = {
       hidden: false
     }, _this._openLink = function (href) {
-      if (isBookmarHref(href)) {
+      if (isBookMarkHref(href)) {
         var id = href.substr(1);
         var el = document.getElementById(id);
         if (el) {
@@ -123,8 +123,8 @@ var LinkTooltip = function (_React$PureComponent) {
           onEdit = _props.onEdit,
           onRemove = _props.onRemove;
 
-      var useBookMark = isBookmarHref(href);
-      var editButton = useBookMark ? null : _react2.default.createElement(_CustomButton2.default, { label: 'Change', onClick: onEdit, value: editorView });
+      var useBookMark = isBookMarkHref(href);
+      var editButton = !!useBookMark && _react2.default.createElement(_CustomButton2.default, { label: 'Change', onClick: onEdit, value: editorView });
 
       return _react2.default.createElement(
         'div',

--- a/dist/ui/LinkTooltip.js
+++ b/dist/ui/LinkTooltip.js
@@ -125,6 +125,7 @@ var LinkTooltip = function (_React$PureComponent) {
 
       var useBookMark = isBookmarHref(href);
       var editButton = useBookMark ? null : _react2.default.createElement(_CustomButton2.default, { label: 'Change', onClick: onEdit, value: editorView });
+
       return _react2.default.createElement(
         'div',
         { className: 'czi-link-tooltip' },
@@ -135,7 +136,8 @@ var LinkTooltip = function (_React$PureComponent) {
             'div',
             { className: 'czi-link-tooltip-row' },
             _react2.default.createElement(_CustomButton2.default, {
-              label: useBookMark ? 'Jump To Bookmark' : 'Open Link',
+              className: useBookMark ? null : 'czi-link-tooltip-href',
+              label: useBookMark ? 'Jump To Bookmark' : href,
               onClick: this._openLink,
               target: 'new',
               title: useBookMark ? null : href,

--- a/dist/ui/LinkTooltip.js
+++ b/dist/ui/LinkTooltip.js
@@ -54,6 +54,10 @@ require('./czi-link-tooltip.css');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+function isBookmarHref(href) {
+  return !!href && href.indexOf('#') === 0 && href.length >= 2;
+}
+
 var LinkTooltip = function (_React$PureComponent) {
   (0, _inherits3.default)(LinkTooltip, _React$PureComponent);
 
@@ -72,7 +76,7 @@ var LinkTooltip = function (_React$PureComponent) {
     return _ret = (_temp = (_this = (0, _possibleConstructorReturn3.default)(this, (_ref = LinkTooltip.__proto__ || (0, _getPrototypeOf2.default)(LinkTooltip)).call.apply(_ref, [this].concat(args))), _this), _this._unmounted = false, _this.state = {
       hidden: false
     }, _this._openLink = function (href) {
-      if (href && href.indexOf('#') === 0) {
+      if (isBookmarHref(href)) {
         var id = href.substr(1);
         var el = document.getElementById(id);
         if (el) {
@@ -119,6 +123,8 @@ var LinkTooltip = function (_React$PureComponent) {
           onEdit = _props.onEdit,
           onRemove = _props.onRemove;
 
+      var useBookMark = isBookmarHref(href);
+      var editButton = useBookMark ? null : _react2.default.createElement(_CustomButton2.default, { label: 'Change', onClick: onEdit, value: editorView });
       return _react2.default.createElement(
         'div',
         { className: 'czi-link-tooltip' },
@@ -129,14 +135,13 @@ var LinkTooltip = function (_React$PureComponent) {
             'div',
             { className: 'czi-link-tooltip-row' },
             _react2.default.createElement(_CustomButton2.default, {
-              className: 'czi-link-tooltip-href',
-              label: href,
+              label: useBookMark ? 'Jump To Bookmark' : 'Open Link',
               onClick: this._openLink,
               target: 'new',
-              title: href,
+              title: useBookMark ? null : href,
               value: href
             }),
-            _react2.default.createElement(_CustomButton2.default, { label: 'Change', onClick: onEdit, value: editorView }),
+            editButton,
             _react2.default.createElement(_CustomButton2.default, {
               label: 'Remove',
               onClick: onRemove,

--- a/dist/ui/LinkTooltip.js.flow
+++ b/dist/ui/LinkTooltip.js.flow
@@ -9,7 +9,7 @@ import CustomButton from './CustomButton';
 
 import './czi-link-tooltip.css';
 
-function isBookmarHref(href: string): boolean {
+function isBookMarkHref(href: string): boolean {
   return !!href && href.indexOf('#') === 0 && href.length >= 2;
 }
 
@@ -30,8 +30,8 @@ class LinkTooltip extends React.PureComponent<any, any, any> {
 
   render(): ?React.Element<any> {
     const {href, editorView, onEdit, onRemove} = this.props;
-    const useBookMark = isBookmarHref(href);
-    const editButton = useBookMark ? null : (
+    const useBookMark = isBookMarkHref(href);
+    const editButton = !!useBookMark && (
       <CustomButton label="Change" onClick={onEdit} value={editorView} />
     );
 
@@ -60,7 +60,7 @@ class LinkTooltip extends React.PureComponent<any, any, any> {
   }
 
   _openLink = (href: string): void => {
-    if (isBookmarHref(href)) {
+    if (isBookMarkHref(href)) {
       const id = href.substr(1);
       const el = document.getElementById(id);
       if (el) {

--- a/dist/ui/LinkTooltip.js.flow
+++ b/dist/ui/LinkTooltip.js.flow
@@ -34,12 +34,14 @@ class LinkTooltip extends React.PureComponent<any, any, any> {
     const editButton = useBookMark ? null : (
       <CustomButton label="Change" onClick={onEdit} value={editorView} />
     );
+
     return (
       <div className="czi-link-tooltip">
         <div className="czi-link-tooltip-body">
           <div className="czi-link-tooltip-row">
             <CustomButton
-              label={useBookMark ? 'Jump To Bookmark' : 'Open Link'}
+              className={useBookMark ? null : 'czi-link-tooltip-href'}
+              label={useBookMark ? 'Jump To Bookmark' : href}
               onClick={this._openLink}
               target="new"
               title={useBookMark ? null : href}

--- a/dist/ui/LinkTooltip.js.flow
+++ b/dist/ui/LinkTooltip.js.flow
@@ -9,6 +9,10 @@ import CustomButton from './CustomButton';
 
 import './czi-link-tooltip.css';
 
+function isBookmarHref(href: string): boolean {
+  return !!href && href.indexOf('#') === 0 && href.length >= 2;
+}
+
 class LinkTooltip extends React.PureComponent<any, any, any> {
   props: {
     editorView: EditorView,
@@ -26,19 +30,22 @@ class LinkTooltip extends React.PureComponent<any, any, any> {
 
   render(): ?React.Element<any> {
     const {href, editorView, onEdit, onRemove} = this.props;
+    const useBookMark = isBookmarHref(href);
+    const editButton = useBookMark ? null : (
+      <CustomButton label="Change" onClick={onEdit} value={editorView} />
+    );
     return (
       <div className="czi-link-tooltip">
         <div className="czi-link-tooltip-body">
           <div className="czi-link-tooltip-row">
             <CustomButton
-              className="czi-link-tooltip-href"
-              label={href}
+              label={useBookMark ? 'Jump To Bookmark' : 'Open Link'}
               onClick={this._openLink}
               target="new"
-              title={href}
+              title={useBookMark ? null : href}
               value={href}
             />
-            <CustomButton label="Change" onClick={onEdit} value={editorView} />
+            {editButton}
             <CustomButton
               label="Remove"
               onClick={onRemove}
@@ -51,7 +58,7 @@ class LinkTooltip extends React.PureComponent<any, any, any> {
   }
 
   _openLink = (href: string): void => {
-    if (href && href.indexOf('#') === 0) {
+    if (isBookmarHref(href)) {
       const id = href.substr(1);
       const el = document.getElementById(id);
       if (el) {

--- a/dist/ui/czi-link-tooltip.css
+++ b/dist/ui/czi-link-tooltip.css
@@ -15,25 +15,11 @@
   margin: 0 3px;
 }
 
-.czi-link-tooltip-href {
-  border: none;
-  color: var(--czi-link-color);
-  display: inline-block;
-  flex: 1;
-  margin: 0 6px 0 0;
-  max-width: 200px;
-  overflow: hidden;
-  padding: 6px 0;
-  position: relative;
-  text-overflow: ellipsis;
-  vertical-align: middle;
-  white-space: nowrap;
-  z-index: 2;
-}
-
 .czi-link-tooltip-row {
   direction: row;
   display: flex;
+  position: relative;
+  z-index: 2;
 }
 
 .czi-link-tooltip-body {

--- a/dist/ui/czi-link-tooltip.css
+++ b/dist/ui/czi-link-tooltip.css
@@ -15,6 +15,22 @@
   margin: 0 3px;
 }
 
+.czi-link-tooltip-href {
+  border: none;
+  color: var(--czi-link-color);
+  display: inline-block;
+  flex: 1;
+  margin: 0 6px 0 0;
+  max-width: 200px;
+  overflow: hidden;
+  padding: 6px 0;
+  position: relative;
+  text-overflow: ellipsis;
+  vertical-align: middle;
+  white-space: nowrap;
+  z-index: 2;
+}
+
 .czi-link-tooltip-row {
   direction: row;
   display: flex;

--- a/src/ui/LinkTooltip.js
+++ b/src/ui/LinkTooltip.js
@@ -9,7 +9,7 @@ import CustomButton from './CustomButton';
 
 import './czi-link-tooltip.css';
 
-function isBookmarHref(href: string): boolean {
+function isBookMarkHref(href: string): boolean {
   return !!href && href.indexOf('#') === 0 && href.length >= 2;
 }
 
@@ -30,8 +30,8 @@ class LinkTooltip extends React.PureComponent<any, any, any> {
 
   render(): ?React.Element<any> {
     const {href, editorView, onEdit, onRemove} = this.props;
-    const useBookMark = isBookmarHref(href);
-    const editButton = useBookMark ? null : (
+    const useBookMark = isBookMarkHref(href);
+    const editButton = !!useBookMark && (
       <CustomButton label="Change" onClick={onEdit} value={editorView} />
     );
 
@@ -60,7 +60,7 @@ class LinkTooltip extends React.PureComponent<any, any, any> {
   }
 
   _openLink = (href: string): void => {
-    if (isBookmarHref(href)) {
+    if (isBookMarkHref(href)) {
       const id = href.substr(1);
       const el = document.getElementById(id);
       if (el) {

--- a/src/ui/LinkTooltip.js
+++ b/src/ui/LinkTooltip.js
@@ -34,12 +34,14 @@ class LinkTooltip extends React.PureComponent<any, any, any> {
     const editButton = useBookMark ? null : (
       <CustomButton label="Change" onClick={onEdit} value={editorView} />
     );
+
     return (
       <div className="czi-link-tooltip">
         <div className="czi-link-tooltip-body">
           <div className="czi-link-tooltip-row">
             <CustomButton
-              label={useBookMark ? 'Jump To Bookmark' : 'Open Link'}
+              className={useBookMark ? null : 'czi-link-tooltip-href'}
+              label={useBookMark ? 'Jump To Bookmark' : href}
               onClick={this._openLink}
               target="new"
               title={useBookMark ? null : href}

--- a/src/ui/LinkTooltip.js
+++ b/src/ui/LinkTooltip.js
@@ -9,6 +9,10 @@ import CustomButton from './CustomButton';
 
 import './czi-link-tooltip.css';
 
+function isBookmarHref(href: string): boolean {
+  return !!href && href.indexOf('#') === 0 && href.length >= 2;
+}
+
 class LinkTooltip extends React.PureComponent<any, any, any> {
   props: {
     editorView: EditorView,
@@ -26,19 +30,22 @@ class LinkTooltip extends React.PureComponent<any, any, any> {
 
   render(): ?React.Element<any> {
     const {href, editorView, onEdit, onRemove} = this.props;
+    const useBookMark = isBookmarHref(href);
+    const editButton = useBookMark ? null : (
+      <CustomButton label="Change" onClick={onEdit} value={editorView} />
+    );
     return (
       <div className="czi-link-tooltip">
         <div className="czi-link-tooltip-body">
           <div className="czi-link-tooltip-row">
             <CustomButton
-              className="czi-link-tooltip-href"
-              label={href}
+              label={useBookMark ? 'Jump To Bookmark' : 'Open Link'}
               onClick={this._openLink}
               target="new"
-              title={href}
+              title={useBookMark ? null : href}
               value={href}
             />
-            <CustomButton label="Change" onClick={onEdit} value={editorView} />
+            {editButton}
             <CustomButton
               label="Remove"
               onClick={onRemove}
@@ -51,7 +58,7 @@ class LinkTooltip extends React.PureComponent<any, any, any> {
   }
 
   _openLink = (href: string): void => {
-    if (href && href.indexOf('#') === 0) {
+    if (isBookmarHref(href)) {
       const id = href.substr(1);
       const el = document.getElementById(id);
       if (el) {

--- a/src/ui/czi-link-tooltip.css
+++ b/src/ui/czi-link-tooltip.css
@@ -15,25 +15,11 @@
   margin: 0 3px;
 }
 
-.czi-link-tooltip-href {
-  border: none;
-  color: var(--czi-link-color);
-  display: inline-block;
-  flex: 1;
-  margin: 0 6px 0 0;
-  max-width: 200px;
-  overflow: hidden;
-  padding: 6px 0;
-  position: relative;
-  text-overflow: ellipsis;
-  vertical-align: middle;
-  white-space: nowrap;
-  z-index: 2;
-}
-
 .czi-link-tooltip-row {
   direction: row;
   display: flex;
+  position: relative;
+  z-index: 2;
 }
 
 .czi-link-tooltip-body {

--- a/src/ui/czi-link-tooltip.css
+++ b/src/ui/czi-link-tooltip.css
@@ -15,6 +15,22 @@
   margin: 0 3px;
 }
 
+.czi-link-tooltip-href {
+  border: none;
+  color: var(--czi-link-color);
+  display: inline-block;
+  flex: 1;
+  margin: 0 6px 0 0;
+  max-width: 200px;
+  overflow: hidden;
+  padding: 6px 0;
+  position: relative;
+  text-overflow: ellipsis;
+  vertical-align: middle;
+  white-space: nowrap;
+  z-index: 2;
+}
+
 .czi-link-tooltip-row {
   direction: row;
   display: flex;


### PR DESCRIPTION
Per feedback from users, make the UI that navigates to  a bookmark less confusing.

| Before| After (For Link) | After (For Bookmark) |
|---|---|---|
| ![image](https://user-images.githubusercontent.com/1504439/57493718-0744bd00-727b-11e9-84cd-bd890f6b2eb9.png) | ![image](https://user-images.githubusercontent.com/1504439/57493769-35c29800-727b-11e9-90de-b9d12c7a2013.png)| ![image](https://user-images.githubusercontent.com/1504439/57493743-1af02380-727b-11e9-897d-f8cd5874de7b.png)
 |
