### PR TITLE
Using Github CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @velveret @fresh-prince-of-prosemirror @hedgerwang


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1504439/57545131-4112d380-730e-11e9-8fbc-8eb3ff229498.png)


GitHub CODEOWNERS file is a simple way to automate away some of the pain associated with the review system on github, by automatically assigning reviewers to a pull request based on which files were modified.

more about the setup
https://github.com/chanzuckerberg/czi-prosemirror/compare/add_code_owners?expand=1