### PR TITLE
Fix font type menu for monospace and Lucida Console.

### DIFF
--- a/dist/ui/findActiveFontType.js
+++ b/dist/ui/findActiveFontType.js
@@ -48,11 +48,5 @@ function findActiveFontType(state) {
     return FONT_TYPE_NAME_DEFAULT;
   }
 
-  var domDoc = typeof document === 'undefined' ? null : document;
-
-  if (domDoc && domDoc.fonts && domDoc.fonts.check) {
-    return domDoc.fonts.check('12px "' + fontName + '"') ? fontName : FONT_TYPE_NAME_DEFAULT;
-  }
-
   return fontName;
 }

--- a/dist/ui/findActiveFontType.js.flow
+++ b/dist/ui/findActiveFontType.js.flow
@@ -34,13 +34,5 @@ export default function findActiveFontType(state: EditorState): string {
     return FONT_TYPE_NAME_DEFAULT;
   }
 
-  const domDoc: any = typeof document === 'undefined' ? null : document;
-
-  if (domDoc && domDoc.fonts && domDoc.fonts.check) {
-    return domDoc.fonts.check('12px "' + fontName + '"')
-      ? fontName
-      : FONT_TYPE_NAME_DEFAULT;
-  }
-
   return fontName;
 }

--- a/src/ui/findActiveFontType.js
+++ b/src/ui/findActiveFontType.js
@@ -34,13 +34,5 @@ export default function findActiveFontType(state: EditorState): string {
     return FONT_TYPE_NAME_DEFAULT;
   }
 
-  const domDoc: any = typeof document === 'undefined' ? null : document;
-
-  if (domDoc && domDoc.fonts && domDoc.fonts.check) {
-    return domDoc.fonts.check('12px "' + fontName + '"')
-      ? fontName
-      : FONT_TYPE_NAME_DEFAULT;
-  }
-
   return fontName;
 }


### PR DESCRIPTION
The `FontFaceSet.check` was failing for monospace and Lucida Console, so the menu would show "Arial" even though the font was successfully set. monospace works if you remove the `"` around the font check, but Lucida Console still didn't work if you remove the quotation marks.
![font-menu](https://user-images.githubusercontent.com/1837091/57890910-51372100-77ee-11e9-8236-4dde8420d2d8.gif)
