### PR TITLE
Calibrate line spacing values.

### DIFF
--- a/dist/TextLineSpacingCommand.js
+++ b/dist/TextLineSpacingCommand.js
@@ -115,7 +115,8 @@ function setTextLineSpacing(tr, schema, lineSpacing) {
 function createGroup() {
   var group = {
     Single: new TextLineSpacingCommand(_toCSSLineSpacing.SINGLE_LINE_SPACING),
-    ' 150% ': new TextLineSpacingCommand('150%'),
+    '1.15': new TextLineSpacingCommand(_toCSSLineSpacing.LINE_SPACING_115),
+    '1.5': new TextLineSpacingCommand(_toCSSLineSpacing.LINE_SPACING_150),
     Double: new TextLineSpacingCommand(_toCSSLineSpacing.DOUBLE_LINE_SPACING)
   };
   return [group];

--- a/dist/TextLineSpacingCommand.js.flow
+++ b/dist/TextLineSpacingCommand.js.flow
@@ -7,7 +7,12 @@ import {EditorState} from 'prosemirror-state';
 import {EditorView} from 'prosemirror-view';
 import {Schema} from 'prosemirror-model';
 import {Transform} from 'prosemirror-transform';
-import {DOUBLE_LINE_SPACING, SINGLE_LINE_SPACING} from './ui/toCSSLineSpacing';
+import {
+  DOUBLE_LINE_SPACING,
+  SINGLE_LINE_SPACING,
+  LINE_SPACING_115,
+  LINE_SPACING_150,
+} from './ui/toCSSLineSpacing';
 
 export function setTextLineSpacing(
   tr: Transform,
@@ -86,7 +91,8 @@ export function setTextLineSpacing(
 function createGroup(): Array<{[string]: TextLineSpacingCommand}> {
   const group = {
     Single: new TextLineSpacingCommand(SINGLE_LINE_SPACING),
-    ' 150% ': new TextLineSpacingCommand('150%'),
+    '1.15': new TextLineSpacingCommand(LINE_SPACING_115),
+    '1.5': new TextLineSpacingCommand(LINE_SPACING_150),
     Double: new TextLineSpacingCommand(DOUBLE_LINE_SPACING),
   };
   return [group];

--- a/dist/ui/czi-vars.css
+++ b/dist/ui/czi-vars.css
@@ -37,6 +37,6 @@
   --czi-content-font-size-h2: 16px;
   --czi-content-font-size-h3: 13px;
   --czi-content-font-size: 11pt;
-  --czi-content-line-height: 1.25;
+  --czi-content-line-height: 150%;
   --czi-content-link-color: rgb(0, 0, 238);
 }

--- a/dist/ui/czi-vars.css
+++ b/dist/ui/czi-vars.css
@@ -37,6 +37,7 @@
   --czi-content-font-size-h2: 16px;
   --czi-content-font-size-h3: 13px;
   --czi-content-font-size: 11pt;
+
   /* This maps to the default line spacing value of 1.5 in Google Doc */
   --czi-content-line-height: 138%;
   --czi-content-link-color: rgb(0, 0, 238);

--- a/dist/ui/czi-vars.css
+++ b/dist/ui/czi-vars.css
@@ -37,6 +37,7 @@
   --czi-content-font-size-h2: 16px;
   --czi-content-font-size-h3: 13px;
   --czi-content-font-size: 11pt;
-  --czi-content-line-height: 150%;
+  /* This maps to the default line spacing value of 1.5 in Google Doc */
+  --czi-content-line-height: 138%;
   --czi-content-link-color: rgb(0, 0, 238);
 }

--- a/dist/ui/toCSSLineSpacing.js
+++ b/dist/ui/toCSSLineSpacing.js
@@ -43,6 +43,10 @@ function toCSSLineSpacing(source) {
   // - Double => 232%
   // The following `if` block will calibrate the value if applicable.
 
+  if (strValue === '100%') {
+    return LINE_SPACING_100;
+  }
+
   if (strValue === '115%') {
     return LINE_SPACING_115;
   }

--- a/dist/ui/toCSSLineSpacing.js
+++ b/dist/ui/toCSSLineSpacing.js
@@ -3,28 +3,23 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.DOUBLE_LINE_SPACING = exports.SINGLE_LINE_SPACING = undefined;
-
-var _set = require('babel-runtime/core-js/set');
-
-var _set2 = _interopRequireDefault(_set);
-
 exports.default = toCSSLineSpacing;
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-var SINGLE_LINE_SPACING = exports.SINGLE_LINE_SPACING = '125%';
-var DOUBLE_LINE_SPACING = exports.DOUBLE_LINE_SPACING = '200%';
+// Line spacing names and their values.
+var LINE_SPACING_100 = exports.LINE_SPACING_100 = '125%';
+var LINE_SPACING_115 = exports.LINE_SPACING_115 = '138%';
+var LINE_SPACING_150 = exports.LINE_SPACING_150 = '165%';
+var LINE_SPACING_200 = exports.LINE_SPACING_200 = '232%';
 
-// In Google Doc, "single line height" is exported as style
-// "line-height: 1.15" which is too narrow to read.
-// This defines the deprecate line spacing values that should me migrated.
-var DEPRECATED_SINGLE_LINE_SPACING_VALUES = new _set2.default(['115%', '100%']);
+var SINGLE_LINE_SPACING = exports.SINGLE_LINE_SPACING = LINE_SPACING_100;
+var DOUBLE_LINE_SPACING = exports.DOUBLE_LINE_SPACING = LINE_SPACING_200;
 
 var NUMBER_VALUE_PATTERN = /^\d+(.\d+)?$/;
 
 // Normalize the css line-height vlaue to percentage-based value if applicable.
-// e.g. This converts "1.5" to "150%".
+// Also, it calibrates the incorrect line spacing value exported from Google
+// Doc.
 function toCSSLineSpacing(source) {
   if (!source) {
     return '';
@@ -38,8 +33,26 @@ function toCSSLineSpacing(source) {
     strValue = String(Math.round(numValue * 100)) + '%';
   }
 
-  if (DEPRECATED_SINGLE_LINE_SPACING_VALUES.has(strValue)) {
-    return SINGLE_LINE_SPACING;
+  // Google Doc exports line spacing with wrong values. For instance:
+  // - Single => 100%
+  // - 1.15 => 115%
+  // - Double => 200%
+  // But the actual CSS value measured in Google Doc is like this:
+  // - Single => 125%
+  // - 1.15 => 138%
+  // - Double => 232%
+  // The following `if` block will calibrate the value if applicable.
+
+  if (strValue === '115%') {
+    return LINE_SPACING_115;
+  }
+
+  if (strValue === '150%') {
+    return LINE_SPACING_150;
+  }
+
+  if (strValue === '200%') {
+    return LINE_SPACING_200;
   }
 
   // e.g. line-height: 15px;

--- a/dist/ui/toCSSLineSpacing.js.flow
+++ b/dist/ui/toCSSLineSpacing.js.flow
@@ -1,17 +1,19 @@
 // @flow
 
-export const SINGLE_LINE_SPACING = '125%';
-export const DOUBLE_LINE_SPACING = '200%';
+// Line spacing names and their values.
+export const LINE_SPACING_100 = '125%';
+export const LINE_SPACING_115 = '138%';
+export const LINE_SPACING_150 = '165%';
+export const LINE_SPACING_200 = '232%';
 
-// In Google Doc, "single line height" is exported as style
-// "line-height: 1.15" which is too narrow to read.
-// This defines the deprecate line spacing values that should me migrated.
-const DEPRECATED_SINGLE_LINE_SPACING_VALUES = new Set(['115%', '100%']);
+export const SINGLE_LINE_SPACING = LINE_SPACING_100;
+export const DOUBLE_LINE_SPACING = LINE_SPACING_200;
 
 const NUMBER_VALUE_PATTERN = /^\d+(.\d+)?$/;
 
 // Normalize the css line-height vlaue to percentage-based value if applicable.
-// e.g. This converts "1.5" to "150%".
+// Also, it calibrates the incorrect line spacing value exported from Google
+// Doc.
 export default function toCSSLineSpacing(source: any): string {
   if (!source) {
     return '';
@@ -25,8 +27,26 @@ export default function toCSSLineSpacing(source: any): string {
     strValue = String(Math.round(numValue * 100)) + '%';
   }
 
-  if (DEPRECATED_SINGLE_LINE_SPACING_VALUES.has(strValue)) {
-    return SINGLE_LINE_SPACING;
+  // Google Doc exports line spacing with wrong values. For instance:
+  // - Single => 100%
+  // - 1.15 => 115%
+  // - Double => 200%
+  // But the actual CSS value measured in Google Doc is like this:
+  // - Single => 125%
+  // - 1.15 => 138%
+  // - Double => 232%
+  // The following `if` block will calibrate the value if applicable.
+
+  if (strValue === '115%') {
+    return LINE_SPACING_115;
+  }
+
+  if (strValue === '150%') {
+    return LINE_SPACING_150;
+  }
+
+  if (strValue === '200%') {
+    return LINE_SPACING_200;
   }
 
   // e.g. line-height: 15px;

--- a/dist/ui/toCSSLineSpacing.js.flow
+++ b/dist/ui/toCSSLineSpacing.js.flow
@@ -37,6 +37,10 @@ export default function toCSSLineSpacing(source: any): string {
   // - Double => 232%
   // The following `if` block will calibrate the value if applicable.
 
+  if (strValue === '100%') {
+    return LINE_SPACING_100;
+  }
+
   if (strValue === '115%') {
     return LINE_SPACING_115;
   }

--- a/src/TextLineSpacingCommand.js
+++ b/src/TextLineSpacingCommand.js
@@ -7,7 +7,12 @@ import {EditorState} from 'prosemirror-state';
 import {EditorView} from 'prosemirror-view';
 import {Schema} from 'prosemirror-model';
 import {Transform} from 'prosemirror-transform';
-import {DOUBLE_LINE_SPACING, SINGLE_LINE_SPACING} from './ui/toCSSLineSpacing';
+import {
+  DOUBLE_LINE_SPACING,
+  SINGLE_LINE_SPACING,
+  LINE_SPACING_115,
+  LINE_SPACING_150,
+} from './ui/toCSSLineSpacing';
 
 export function setTextLineSpacing(
   tr: Transform,
@@ -86,7 +91,8 @@ export function setTextLineSpacing(
 function createGroup(): Array<{[string]: TextLineSpacingCommand}> {
   const group = {
     Single: new TextLineSpacingCommand(SINGLE_LINE_SPACING),
-    ' 150% ': new TextLineSpacingCommand('150%'),
+    '1.15': new TextLineSpacingCommand(LINE_SPACING_115),
+    '1.5': new TextLineSpacingCommand(LINE_SPACING_150),
     Double: new TextLineSpacingCommand(DOUBLE_LINE_SPACING),
   };
   return [group];

--- a/src/ui/czi-vars.css
+++ b/src/ui/czi-vars.css
@@ -37,6 +37,6 @@
   --czi-content-font-size-h2: 16px;
   --czi-content-font-size-h3: 13px;
   --czi-content-font-size: 11pt;
-  --czi-content-line-height: 1.25;
+  --czi-content-line-height: 150%;
   --czi-content-link-color: rgb(0, 0, 238);
 }

--- a/src/ui/czi-vars.css
+++ b/src/ui/czi-vars.css
@@ -37,6 +37,7 @@
   --czi-content-font-size-h2: 16px;
   --czi-content-font-size-h3: 13px;
   --czi-content-font-size: 11pt;
+
   /* This maps to the default line spacing value of 1.5 in Google Doc */
   --czi-content-line-height: 138%;
   --czi-content-link-color: rgb(0, 0, 238);

--- a/src/ui/czi-vars.css
+++ b/src/ui/czi-vars.css
@@ -37,6 +37,7 @@
   --czi-content-font-size-h2: 16px;
   --czi-content-font-size-h3: 13px;
   --czi-content-font-size: 11pt;
-  --czi-content-line-height: 150%;
+  /* This maps to the default line spacing value of 1.5 in Google Doc */
+  --czi-content-line-height: 138%;
   --czi-content-link-color: rgb(0, 0, 238);
 }

--- a/src/ui/toCSSLineSpacing.js
+++ b/src/ui/toCSSLineSpacing.js
@@ -1,17 +1,19 @@
 // @flow
 
-export const SINGLE_LINE_SPACING = '125%';
-export const DOUBLE_LINE_SPACING = '200%';
+// Line spacing names and their values.
+export const LINE_SPACING_100 = '125%';
+export const LINE_SPACING_115 = '138%';
+export const LINE_SPACING_150 = '165%';
+export const LINE_SPACING_200 = '232%';
 
-// In Google Doc, "single line height" is exported as style
-// "line-height: 1.15" which is too narrow to read.
-// This defines the deprecate line spacing values that should me migrated.
-const DEPRECATED_SINGLE_LINE_SPACING_VALUES = new Set(['115%', '100%']);
+export const SINGLE_LINE_SPACING = LINE_SPACING_100;
+export const DOUBLE_LINE_SPACING = LINE_SPACING_200;
 
 const NUMBER_VALUE_PATTERN = /^\d+(.\d+)?$/;
 
 // Normalize the css line-height vlaue to percentage-based value if applicable.
-// e.g. This converts "1.5" to "150%".
+// Also, it calibrates the incorrect line spacing value exported from Google
+// Doc.
 export default function toCSSLineSpacing(source: any): string {
   if (!source) {
     return '';
@@ -25,8 +27,26 @@ export default function toCSSLineSpacing(source: any): string {
     strValue = String(Math.round(numValue * 100)) + '%';
   }
 
-  if (DEPRECATED_SINGLE_LINE_SPACING_VALUES.has(strValue)) {
-    return SINGLE_LINE_SPACING;
+  // Google Doc exports line spacing with wrong values. For instance:
+  // - Single => 100%
+  // - 1.15 => 115%
+  // - Double => 200%
+  // But the actual CSS value measured in Google Doc is like this:
+  // - Single => 125%
+  // - 1.15 => 138%
+  // - Double => 232%
+  // The following `if` block will calibrate the value if applicable.
+
+  if (strValue === '115%') {
+    return LINE_SPACING_115;
+  }
+
+  if (strValue === '150%') {
+    return LINE_SPACING_150;
+  }
+
+  if (strValue === '200%') {
+    return LINE_SPACING_200;
   }
 
   // e.g. line-height: 15px;

--- a/src/ui/toCSSLineSpacing.js
+++ b/src/ui/toCSSLineSpacing.js
@@ -37,6 +37,10 @@ export default function toCSSLineSpacing(source: any): string {
   // - Double => 232%
   // The following `if` block will calibrate the value if applicable.
 
+  if (strValue === '100%') {
+    return LINE_SPACING_100;
+  }
+
   if (strValue === '115%') {
     return LINE_SPACING_115;
   }


### PR DESCRIPTION
I just realized that all the line spacing values exported by Google can't be used directly. 

After doing a precise measurement of different line spacing values exported from Google, I update our own logic that normalized the line spacing values. 

Also, I change the default line spacing value from "125" to "138%", so it uses the same line spacing value as Google dos.

![00000000](https://user-images.githubusercontent.com/1504439/57959106-11883c00-78b7-11e9-89c5-a10da663d753.gif)

