### PR TITLE
Fix resizing nested tables.

### DIFF
--- a/dist/TableResizePlugin.js
+++ b/dist/TableResizePlugin.js
@@ -16,13 +16,13 @@ var _inherits2 = require('babel-runtime/helpers/inherits');
 
 var _inherits3 = _interopRequireDefault(_inherits2);
 
-var _extends2 = require('babel-runtime/helpers/extends');
-
-var _extends3 = _interopRequireDefault(_extends2);
-
 var _from = require('babel-runtime/core-js/array/from');
 
 var _from2 = _interopRequireDefault(_from);
+
+var _extends2 = require('babel-runtime/helpers/extends');
+
+var _extends3 = _interopRequireDefault(_extends2);
 
 var _classCallCheck2 = require('babel-runtime/helpers/classCallCheck');
 
@@ -185,8 +185,10 @@ function handleMouseDown(view, event) {
   if (resizeState.cellPos === -1 || resizeState.draggingInfo) {
     return false;
   }
+
+  var draginfo = calculateDraggingInfo(view, event, resizeState);
   view.dispatch(view.state.tr.setMeta(PLUGIN_KEY, {
-    setDraggingInfo: calculateDraggingInfo(view, event, resizeState)
+    setDraggingInfo: draginfo
   }));
 
   // Move events should be batched to avoid over-handling the mouse
@@ -288,7 +290,7 @@ function handleDragEnd(view, event) {
   var columnElements = draggingInfo.columnElements,
       tableElement = draggingInfo.tableElement;
 
-  var widths = (0, _from2.default)(columnElements).map(function (colEl) {
+  var widths = columnElements.map(function (colEl) {
     return parseFloat(colEl.style.width);
   });
 
@@ -349,7 +351,8 @@ function calculateDraggingInfo(view, event, resizeState) {
   var dom = view.domAtPos(cellPos);
   var tableEl = dom.node.closest('table');
   var tableWrapper = tableEl.closest('.tableWrapper');
-  var colEls = tableEl.querySelectorAll('colgroup > col');
+  var colGroupEl = tableEl.querySelector('colgroup');
+  var colEls = colGroupEl ? (0, _from2.default)(colGroupEl.querySelectorAll('col')) : [];
   var tableWrapperRect = tableWrapper.getBoundingClientRect();
   var tableRect = tableEl.getBoundingClientRect();
   var defaultColumnWidth = tableWrapperRect.width / colEls.length;

--- a/dist/TableResizePlugin.js
+++ b/dist/TableResizePlugin.js
@@ -186,9 +186,8 @@ function handleMouseDown(view, event) {
     return false;
   }
 
-  var draginfo = calculateDraggingInfo(view, event, resizeState);
   view.dispatch(view.state.tr.setMeta(PLUGIN_KEY, {
-    setDraggingInfo: draginfo
+    setDraggingInfo: calculateDraggingInfo(view, event, resizeState)
   }));
 
   // Move events should be batched to avoid over-handling the mouse

--- a/dist/TableResizePlugin.js.flow
+++ b/dist/TableResizePlugin.js.flow
@@ -169,9 +169,11 @@ function handleMouseDown(view: EditorView, event: MouseEvent): boolean {
   if (resizeState.cellPos === -1 || resizeState.draggingInfo) {
     return false;
   }
+
+  const draginfo = calculateDraggingInfo(view, event, resizeState);
   view.dispatch(
     view.state.tr.setMeta(PLUGIN_KEY, {
-      setDraggingInfo: calculateDraggingInfo(view, event, resizeState),
+      setDraggingInfo: draginfo,
     })
   );
 
@@ -275,7 +277,7 @@ function handleDragEnd(view: EditorView, event: PointerEvent): void {
     return;
   }
   const {columnElements, tableElement} = draggingInfo;
-  const widths = Array.from(columnElements).map(colEl => {
+  const widths = columnElements.map(colEl => {
     return parseFloat(colEl.style.width);
   });
 
@@ -345,7 +347,10 @@ function calculateDraggingInfo(
   const dom = view.domAtPos(cellPos);
   const tableEl = dom.node.closest('table');
   const tableWrapper = tableEl.closest('.tableWrapper');
-  const colEls = tableEl.querySelectorAll('colgroup > col');
+  const colGroupEl = tableEl.querySelector('colgroup');
+  const colEls = colGroupEl
+    ? Array.from(colGroupEl.querySelectorAll('col'))
+    : [];
   const tableWrapperRect = tableWrapper.getBoundingClientRect();
   const tableRect = tableEl.getBoundingClientRect();
   const defaultColumnWidth = tableWrapperRect.width / colEls.length;

--- a/dist/TableResizePlugin.js.flow
+++ b/dist/TableResizePlugin.js.flow
@@ -170,10 +170,9 @@ function handleMouseDown(view: EditorView, event: MouseEvent): boolean {
     return false;
   }
 
-  const draginfo = calculateDraggingInfo(view, event, resizeState);
   view.dispatch(
     view.state.tr.setMeta(PLUGIN_KEY, {
-      setDraggingInfo: draginfo,
+      setDraggingInfo: calculateDraggingInfo(view, event, resizeState),
     })
   );
 

--- a/src/TableResizePlugin.js
+++ b/src/TableResizePlugin.js
@@ -169,9 +169,11 @@ function handleMouseDown(view: EditorView, event: MouseEvent): boolean {
   if (resizeState.cellPos === -1 || resizeState.draggingInfo) {
     return false;
   }
+
+  const draginfo = calculateDraggingInfo(view, event, resizeState);
   view.dispatch(
     view.state.tr.setMeta(PLUGIN_KEY, {
-      setDraggingInfo: calculateDraggingInfo(view, event, resizeState),
+      setDraggingInfo: draginfo,
     })
   );
 
@@ -275,7 +277,7 @@ function handleDragEnd(view: EditorView, event: PointerEvent): void {
     return;
   }
   const {columnElements, tableElement} = draggingInfo;
-  const widths = Array.from(columnElements).map(colEl => {
+  const widths = columnElements.map(colEl => {
     return parseFloat(colEl.style.width);
   });
 
@@ -345,7 +347,10 @@ function calculateDraggingInfo(
   const dom = view.domAtPos(cellPos);
   const tableEl = dom.node.closest('table');
   const tableWrapper = tableEl.closest('.tableWrapper');
-  const colEls = tableEl.querySelectorAll('colgroup > col');
+  const colGroupEl = tableEl.querySelector('colgroup');
+  const colEls = colGroupEl
+    ? Array.from(colGroupEl.querySelectorAll('col'))
+    : [];
   const tableWrapperRect = tableWrapper.getBoundingClientRect();
   const tableRect = tableEl.getBoundingClientRect();
   const defaultColumnWidth = tableWrapperRect.width / colEls.length;

--- a/src/TableResizePlugin.js
+++ b/src/TableResizePlugin.js
@@ -170,10 +170,9 @@ function handleMouseDown(view: EditorView, event: MouseEvent): boolean {
     return false;
   }
 
-  const draginfo = calculateDraggingInfo(view, event, resizeState);
   view.dispatch(
     view.state.tr.setMeta(PLUGIN_KEY, {
-      setDraggingInfo: draginfo,
+      setDraggingInfo: calculateDraggingInfo(view, event, resizeState),
     })
   );
 


### PR DESCRIPTION
When a table element is being resized, we should only check its own column elements, not all the column elements within.

This addresses the issue reported at  #73 