### PR TITLE
Ensures that the adjacent ordered lists within the same indent level …

### DIFF
--- a/dist/OrderedListNodeSpec.js
+++ b/dist/OrderedListNodeSpec.js
@@ -29,7 +29,7 @@ var OrderedListNodeSpec = {
     counterReset: { default: null },
     indent: { default: _ParagraphNodeSpec.MIN_INDENT_LEVEL },
     listStyleType: { default: null },
-    start: { default: null }
+    start: { default: 1 }
   },
   group: 'block',
   content: _NodeNames.LIST_ITEM + '+',
@@ -39,7 +39,7 @@ var OrderedListNodeSpec = {
       var listStyleType = dom.getAttribute(_ListItemNodeSpec.ATTRIBUTE_LIST_STYLE_TYPE);
       var counterReset = dom.getAttribute(ATTRIBUTE_COUNTER_RESET) || undefined;
 
-      var start = dom.hasAttribute('start') ? parseInt(dom.getAttribute('start'), 10) : null;
+      var start = dom.hasAttribute('start') ? parseInt(dom.getAttribute('start'), 10) : 1;
 
       var indent = dom.hasAttribute(_ParagraphNodeSpec.ATTRIBUTE_INDENT) ? parseInt(dom.getAttribute(_ParagraphNodeSpec.ATTRIBUTE_INDENT), 10) : _ParagraphNodeSpec.MIN_INDENT_LEVEL;
 
@@ -67,7 +67,7 @@ var OrderedListNodeSpec = {
       attrs[_ListItemNodeSpec.ATTRIBUTE_LIST_STYLE_TYPE] = listStyleType;
     }
 
-    if (start !== 1 && start !== null) {
+    if (start !== 1) {
       attrs.start = start;
     }
 
@@ -79,7 +79,7 @@ var OrderedListNodeSpec = {
 
     var cssCounterName = 'czi-counter-' + indent;
 
-    attrs.style = '--czi-counter-name: ' + cssCounterName + ';' + ('--czi-list-style-type: ' + htmlListStyleType) + ('--czi-counter-reset: ' + (start - 1) + ';');
+    attrs.style = '--czi-counter-name: ' + cssCounterName + ';' + ('--czi-counter-reset: ' + (start - 1) + ';') + ('--czi-list-style-type: ' + htmlListStyleType);
 
     attrs.type = htmlListStyleType;
 

--- a/dist/OrderedListNodeSpec.js
+++ b/dist/OrderedListNodeSpec.js
@@ -20,14 +20,16 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 var babelPluginFlowReactPropTypes_proptype_NodeSpec = require('./Types').babelPluginFlowReactPropTypes_proptype_NodeSpec || require('prop-types').any;
 
+var ATTRIBUTE_COUNTER_RESET = 'data-counter-reset';
 var AUTO_LIST_STYLE_TYPES = ['decimal', 'lower-alpha', 'lower-roman'];
 
 var OrderedListNodeSpec = {
   attrs: {
-    id: { default: 1 },
+    id: { default: null },
+    counterReset: { default: null },
     indent: { default: _ParagraphNodeSpec.MIN_INDENT_LEVEL },
     listStyleType: { default: null },
-    start: { default: 1 }
+    start: { default: null }
   },
   group: 'block',
   content: _NodeNames.LIST_ITEM + '+',
@@ -35,12 +37,14 @@ var OrderedListNodeSpec = {
     tag: 'ol',
     getAttrs: function getAttrs(dom) {
       var listStyleType = dom.getAttribute(_ListItemNodeSpec.ATTRIBUTE_LIST_STYLE_TYPE);
+      var counterReset = dom.getAttribute(ATTRIBUTE_COUNTER_RESET) || undefined;
 
-      var start = dom.hasAttribute('start') ? parseInt(dom.getAttribute('start'), 10) : 1;
+      var start = dom.hasAttribute('start') ? parseInt(dom.getAttribute('start'), 10) : null;
 
       var indent = dom.hasAttribute(_ParagraphNodeSpec.ATTRIBUTE_INDENT) ? parseInt(dom.getAttribute(_ParagraphNodeSpec.ATTRIBUTE_INDENT), 10) : _ParagraphNodeSpec.MIN_INDENT_LEVEL;
 
       return {
+        counterReset: counterReset,
         indent: indent,
         listStyleType: listStyleType,
         start: start
@@ -51,15 +55,19 @@ var OrderedListNodeSpec = {
     var _node$attrs = node.attrs,
         start = _node$attrs.start,
         indent = _node$attrs.indent,
-        listStyleType = _node$attrs.listStyleType;
+        listStyleType = _node$attrs.listStyleType,
+        counterReset = _node$attrs.counterReset;
 
     var attrs = (0, _defineProperty3.default)({}, _ParagraphNodeSpec.ATTRIBUTE_INDENT, indent);
+    if (counterReset === 'none') {
+      attrs[ATTRIBUTE_COUNTER_RESET] = counterReset;
+    }
 
     if (listStyleType) {
       attrs[_ListItemNodeSpec.ATTRIBUTE_LIST_STYLE_TYPE] = listStyleType;
     }
 
-    if (start !== _ParagraphNodeSpec.MIN_INDENT_LEVEL) {
+    if (start !== 1 && start !== null) {
       attrs.start = start;
     }
 
@@ -71,7 +79,7 @@ var OrderedListNodeSpec = {
 
     var cssCounterName = 'czi-counter-' + indent;
 
-    attrs.style = '--czi-counter-name: ' + cssCounterName + ';' + ('--czi-counter-reset: ' + (start - 1) + ';') + ('--czi-list-style-type: ' + htmlListStyleType);
+    attrs.style = '--czi-counter-name: ' + cssCounterName + ';' + ('--czi-list-style-type: ' + htmlListStyleType) + ('--czi-counter-reset: ' + (start - 1) + ';');
 
     attrs.type = htmlListStyleType;
 

--- a/dist/OrderedListNodeSpec.js.flow
+++ b/dist/OrderedListNodeSpec.js.flow
@@ -17,7 +17,7 @@ const OrderedListNodeSpec: NodeSpec = {
     counterReset: {default: null},
     indent: {default: MIN_INDENT_LEVEL},
     listStyleType: {default: null},
-    start: {default: null},
+    start: {default: 1},
   },
   group: 'block',
   content: LIST_ITEM + '+',
@@ -31,7 +31,7 @@ const OrderedListNodeSpec: NodeSpec = {
 
         const start = dom.hasAttribute('start')
           ? parseInt(dom.getAttribute('start'), 10)
-          : null;
+          : 1;
 
         const indent = dom.hasAttribute(ATTRIBUTE_INDENT)
           ? parseInt(dom.getAttribute(ATTRIBUTE_INDENT), 10)
@@ -59,7 +59,7 @@ const OrderedListNodeSpec: NodeSpec = {
       attrs[ATTRIBUTE_LIST_STYLE_TYPE] = listStyleType;
     }
 
-    if (start !== 1 && start !== null) {
+    if (start !== 1) {
       attrs.start = start;
     }
 
@@ -74,8 +74,8 @@ const OrderedListNodeSpec: NodeSpec = {
 
     attrs.style =
       `--czi-counter-name: ${cssCounterName};` +
-      `--czi-list-style-type: ${htmlListStyleType}` +
-      `--czi-counter-reset: ${start - 1};`;
+      `--czi-counter-reset: ${start - 1};` +
+      `--czi-list-style-type: ${htmlListStyleType}`;
 
     attrs.type = htmlListStyleType;
 

--- a/dist/OrderedListNodeSpec.js.flow
+++ b/dist/OrderedListNodeSpec.js.flow
@@ -8,14 +8,16 @@ import {ATTRIBUTE_INDENT, MIN_INDENT_LEVEL} from './ParagraphNodeSpec';
 
 import type {NodeSpec} from './Types';
 
+const ATTRIBUTE_COUNTER_RESET = 'data-counter-reset';
 const AUTO_LIST_STYLE_TYPES = ['decimal', 'lower-alpha', 'lower-roman'];
 
 const OrderedListNodeSpec: NodeSpec = {
   attrs: {
-    id: {default: 1},
+    id: {default: null},
+    counterReset: {default: null},
     indent: {default: MIN_INDENT_LEVEL},
     listStyleType: {default: null},
-    start: {default: 1},
+    start: {default: null},
   },
   group: 'block',
   content: LIST_ITEM + '+',
@@ -24,16 +26,19 @@ const OrderedListNodeSpec: NodeSpec = {
       tag: 'ol',
       getAttrs(dom: HTMLElement) {
         const listStyleType = dom.getAttribute(ATTRIBUTE_LIST_STYLE_TYPE);
+        const counterReset =
+          dom.getAttribute(ATTRIBUTE_COUNTER_RESET) || undefined;
 
         const start = dom.hasAttribute('start')
           ? parseInt(dom.getAttribute('start'), 10)
-          : 1;
+          : null;
 
         const indent = dom.hasAttribute(ATTRIBUTE_INDENT)
           ? parseInt(dom.getAttribute(ATTRIBUTE_INDENT), 10)
           : MIN_INDENT_LEVEL;
 
         return {
+          counterReset,
           indent,
           listStyleType,
           start,
@@ -42,16 +47,19 @@ const OrderedListNodeSpec: NodeSpec = {
     },
   ],
   toDOM(node: Node) {
-    const {start, indent, listStyleType} = node.attrs;
+    const {start, indent, listStyleType, counterReset} = node.attrs;
     const attrs: Object = {
       [ATTRIBUTE_INDENT]: indent,
     };
+    if (counterReset === 'none') {
+      attrs[ATTRIBUTE_COUNTER_RESET] = counterReset;
+    }
 
     if (listStyleType) {
       attrs[ATTRIBUTE_LIST_STYLE_TYPE] = listStyleType;
     }
 
-    if (start !== MIN_INDENT_LEVEL) {
+    if (start !== 1 && start !== null) {
       attrs.start = start;
     }
 
@@ -66,8 +74,8 @@ const OrderedListNodeSpec: NodeSpec = {
 
     attrs.style =
       `--czi-counter-name: ${cssCounterName};` +
-      `--czi-counter-reset: ${start - 1};` +
-      `--czi-list-style-type: ${htmlListStyleType}`;
+      `--czi-list-style-type: ${htmlListStyleType}` +
+      `--czi-counter-reset: ${start - 1};`;
 
     attrs.type = htmlListStyleType;
 

--- a/dist/consolidateListNodes.js
+++ b/dist/consolidateListNodes.js
@@ -98,7 +98,7 @@ function linkOrderedListCounters(tr) {
   tr.doc.nodesBetween(from, to, function (node, pos, parentNode) {
     var willTraverseNodeChildren = true;
     if ((0, _isListNode2.default)(node)) {
-      // List Node can't be nested, no need to travere its children.
+      // List Node can't be nested, no need to traverse its children.
       willTraverseNodeChildren = false;
       var indent = node.attrs.indent || 0;
       var start = node.attrs.start || 1;

--- a/dist/consolidateListNodes.js
+++ b/dist/consolidateListNodes.js
@@ -3,7 +3,16 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+
+var _extends2 = require('babel-runtime/helpers/extends');
+
+var _extends3 = _interopRequireDefault(_extends2);
+
 exports.default = consolidateListNodes;
+
+var _isOrderedListNode = require('./isOrderedListNode');
+
+var _isOrderedListNode2 = _interopRequireDefault(_isOrderedListNode);
 
 var _isListNode = require('./isListNode');
 
@@ -41,8 +50,138 @@ function consolidateListNodes(tr) {
       tr = tr.insert(_insertAt, _content);
       prevJointInfo = jointInfo;
     } else {
+      tr = linkOrderedListCounters(tr);
       break;
     }
+  }
+  return tr;
+}
+
+/**
+ * This ensures that the adjacent ordered lists within the same indent level
+ * share the same counter.
+ *
+ * For example, the following three lists:
+ *   --------
+ *   1. AAA
+ *   2. BBB
+ *   --------
+ *     a. CCC
+ *     d. DDD
+ *   --------
+ *   1. EEE
+ *   2. FFF
+ *   --------
+ * Will transform into
+ *   --------
+ *   1. AAA
+ *   2. BBB
+ *   --------
+ *     a. CCC
+ *     d. DDD
+ *   --------
+ *   3. EEE
+ *   4. FFF
+ *   --------
+ * This means that the t1st and the 3rd lists are linked.
+ */
+
+
+function linkOrderedListCounters(tr) {
+  var from = 1;
+  var to = tr.doc.nodeSize - 2;
+  if (from >= to) {
+    return tr;
+  }
+
+  var listsBefore = null;
+  tr.doc.nodesBetween(from, to, function (node, pos, parentNode) {
+    var willTraverseNodeChildren = true;
+    if ((0, _isListNode2.default)(node)) {
+      // List Node can't be nested, no need to travere its children.
+      willTraverseNodeChildren = false;
+      var indent = node.attrs.indent || 0;
+      var start = node.attrs.start || 1;
+      if (listsBefore) {
+        if (start === 1 && (0, _isOrderedListNode2.default)(node)) {
+          // Look backward until we could find another ordered list node to
+          // link with.
+          var counterIsLinked = void 0;
+          listsBefore.some(function (list, index) {
+            if (list.node.type !== node.type && list.indent === indent) {
+              // This encounters different type of list node (e.g a bullet
+              // list node), we need to restart the counter.
+              // ------
+              // 1. AAA
+              // 2. BBB
+              // ------
+              // -. CCC
+              // -. DDD
+              // ------
+              // 1. DDD <- Counter restarts here.
+              // 2. EEE
+              // ------
+              counterIsLinked = false;
+              return true;
+            } else if (list.indent < indent) {
+              // This encounters an ordered list node that has less indent.
+              // we need to restart the counter.
+              // ------
+              // 1. AAA
+              // 2. BBB
+              // ------
+              //   1. DDD <- Counter restarts here.
+              //   2. EEE
+              // ------
+              counterIsLinked = false;
+              return true;
+            } else if (list.indent === indent) {
+              // This encounters an ordered list node that has same indent.
+              // Do not Restart the counter.
+              // ------
+              // 1. AAA
+              // 2. BBB
+              // ------
+              // 3. DDD <- Counter continues here.
+              // 4. EEE
+              // ------
+              counterIsLinked = true;
+              return true;
+            }
+            return false;
+          });
+
+          if (counterIsLinked !== undefined) {
+            tr = setCounterLinked(tr, pos, counterIsLinked);
+          }
+        }
+      } else {
+        // Found the first list.
+        // ------
+        // 1. AAA <- Counter restarts here.
+        // 2. BBB
+        listsBefore = [];
+        if ((0, _isOrderedListNode2.default)(node)) {
+          tr = setCounterLinked(tr, pos, false);
+        }
+      }
+      listsBefore.unshift({ parentNode: parentNode, indent: indent, node: node });
+    } else {
+      // Not traversing withing any list node. No lists need to be updated.
+      listsBefore = null;
+    }
+    return willTraverseNodeChildren;
+  });
+  return tr;
+}
+
+function setCounterLinked(tr, pos, linked) {
+  var node = tr.doc.nodeAt(pos);
+  var currentValue = node.attrs.counterReset || null;
+  var nextValue = linked ? 'none' : null;
+  if (nextValue !== currentValue) {
+    var nodeAttrs = (0, _extends3.default)({}, node.attrs, { counterReset: nextValue });
+    tr = tr.setNodeMarkup(pos, node.type, nodeAttrs, node.marks);
   }
   return tr;
 }

--- a/dist/consolidateListNodes.js
+++ b/dist/consolidateListNodes.js
@@ -83,7 +83,7 @@ function consolidateListNodes(tr) {
  *   3. EEE
  *   4. FFF
  *   --------
- * This means that the t1st and the 3rd lists are linked.
+ * This means that the 1st and the 3rd lists are linked.
  */
 
 
@@ -167,7 +167,7 @@ function linkOrderedListCounters(tr) {
       }
       listsBefore.unshift({ parentNode: parentNode, indent: indent, node: node });
     } else {
-      // Not traversing withing any list node. No lists need to be updated.
+      // Not traversing within any list node. No lists need to be updated.
       listsBefore = null;
     }
     return willTraverseNodeChildren;

--- a/dist/consolidateListNodes.js.flow
+++ b/dist/consolidateListNodes.js.flow
@@ -82,7 +82,7 @@ function linkOrderedListCounters(tr: Transform): Transform {
   tr.doc.nodesBetween(from, to, (node, pos, parentNode) => {
     let willTraverseNodeChildren = true;
     if (isListNode(node)) {
-      // List Node can't be nested, no need to travere its children.
+      // List Node can't be nested, no need to traverse its children.
       willTraverseNodeChildren = false;
       const indent = node.attrs.indent || 0;
       const start = node.attrs.start || 1;

--- a/dist/consolidateListNodes.js.flow
+++ b/dist/consolidateListNodes.js.flow
@@ -69,7 +69,7 @@ export default function consolidateListNodes(tr: Transform): Transform {
  *   3. EEE
  *   4. FFF
  *   --------
- * This means that the t1st and the 3rd lists are linked.
+ * This means that the 1st and the 3rd lists are linked.
  */
 function linkOrderedListCounters(tr: Transform): Transform {
   const from = 1;
@@ -151,7 +151,7 @@ function linkOrderedListCounters(tr: Transform): Transform {
       }
       listsBefore.unshift({parentNode, indent, node});
     } else {
-      // Not traversing withing any list node. No lists need to be updated.
+      // Not traversing within any list node. No lists need to be updated.
       listsBefore = null;
     }
     return willTraverseNodeChildren;

--- a/dist/consolidateListNodes.js.flow
+++ b/dist/consolidateListNodes.js.flow
@@ -1,5 +1,6 @@
 // @flow
 
+import isOrderedListNode from './isOrderedListNode';
 import isListNode from './isListNode';
 import {Fragment} from 'prosemirror-model';
 import {Node} from 'prosemirror-model';
@@ -11,6 +12,13 @@ type JointInfo = {
   deleteTo: number,
   firstListNodePos: number,
   insertAt: number,
+};
+
+type NodeInfo = {
+  node: Node,
+  pos: number,
+  parentNode: ?Node,
+  prev: ?NodeInfo,
 };
 
 // Consolidate list nodes.
@@ -35,8 +43,140 @@ export default function consolidateListNodes(tr: Transform): Transform {
       tr = tr.insert(insertAt, content);
       prevJointInfo = jointInfo;
     } else {
+      tr = linkOrderedListCounters(tr);
       break;
     }
+  }
+  return tr;
+}
+
+/**
+ * This ensures that the adjacent ordered lists within the same indent level
+ * share the same counter.
+ *
+ * For example, the following three lists:
+ *   --------
+ *   1. AAA
+ *   2. BBB
+ *   --------
+ *     a. CCC
+ *     d. DDD
+ *   --------
+ *   1. EEE
+ *   2. FFF
+ *   --------
+ * Will transform into
+ *   --------
+ *   1. AAA
+ *   2. BBB
+ *   --------
+ *     a. CCC
+ *     d. DDD
+ *   --------
+ *   3. EEE
+ *   4. FFF
+ *   --------
+ * This means that the t1st and the 3rd lists are linked.
+ */
+function linkOrderedListCounters(tr: Transform): Transform {
+  const from = 1;
+  const to = tr.doc.nodeSize - 2;
+  if (from >= to) {
+    return tr;
+  }
+
+  let listsBefore = null;
+  tr.doc.nodesBetween(from, to, (node, pos, parentNode) => {
+    let willTraverseNodeChildren = true;
+    if (isListNode(node)) {
+      // List Node can't be nested, no need to travere its children.
+      willTraverseNodeChildren = false;
+      const indent = node.attrs.indent || 0;
+      const start = node.attrs.start || 1;
+      if (listsBefore) {
+        if (start === 1 && isOrderedListNode(node)) {
+          // Look backward until we could find another ordered list node to
+          // link with.
+          let counterIsLinked;
+          listsBefore.some((list, index) => {
+            if (list.node.type !== node.type && list.indent === indent) {
+              // This encounters different type of list node (e.g a bullet
+              // list node), we need to restart the counter.
+              // ------
+              // 1. AAA
+              // 2. BBB
+              // ------
+              // -. CCC
+              // -. DDD
+              // ------
+              // 1. DDD <- Counter restarts here.
+              // 2. EEE
+              // ------
+              counterIsLinked = false;
+              return true;
+            } else if (list.indent < indent) {
+              // This encounters an ordered list node that has less indent.
+              // we need to restart the counter.
+              // ------
+              // 1. AAA
+              // 2. BBB
+              // ------
+              //   1. DDD <- Counter restarts here.
+              //   2. EEE
+              // ------
+              counterIsLinked = false;
+              return true;
+            } else if (list.indent === indent) {
+              // This encounters an ordered list node that has same indent.
+              // Do not Restart the counter.
+              // ------
+              // 1. AAA
+              // 2. BBB
+              // ------
+              // 3. DDD <- Counter continues here.
+              // 4. EEE
+              // ------
+              counterIsLinked = true;
+              return true;
+            }
+            return false;
+          });
+
+          if (counterIsLinked !== undefined) {
+            tr = setCounterLinked(tr, pos, counterIsLinked);
+          }
+        }
+      } else {
+        // Found the first list.
+        // ------
+        // 1. AAA <- Counter restarts here.
+        // 2. BBB
+        listsBefore = [];
+        if (isOrderedListNode(node)) {
+          tr = setCounterLinked(tr, pos, false);
+        }
+      }
+      listsBefore.unshift({parentNode, indent, node});
+    } else {
+      // Not traversing withing any list node. No lists need to be updated.
+      listsBefore = null;
+    }
+    return willTraverseNodeChildren;
+  });
+  return tr;
+}
+
+function setCounterLinked(
+  tr: Transform,
+  pos: number,
+  linked: boolean
+): Transform {
+  const node = tr.doc.nodeAt(pos);
+  const currentValue = node.attrs.counterReset || null;
+  const nextValue = linked ? 'none' : null;
+  if (nextValue !== currentValue) {
+    const nodeAttrs = {...node.attrs, counterReset: nextValue};
+    tr = tr.setNodeMarkup(pos, node.type, nodeAttrs, node.marks);
   }
   return tr;
 }

--- a/dist/consolidateListNodes.js.flow
+++ b/dist/consolidateListNodes.js.flow
@@ -14,13 +14,6 @@ type JointInfo = {
   insertAt: number,
 };
 
-type NodeInfo = {
-  node: Node,
-  pos: number,
-  parentNode: ?Node,
-  prev: ?NodeInfo,
-};
-
 // Consolidate list nodes.
 // All adjacent list nodes with the same list type and indent level will be
 // joined into one list node.

--- a/dist/toggleList.js
+++ b/dist/toggleList.js
@@ -11,6 +11,10 @@ var _extends3 = _interopRequireDefault(_extends2);
 exports.default = toggleList;
 exports.unwrapNodesFromList = unwrapNodesFromList;
 
+var _consolidateListNodes = require('./consolidateListNodes');
+
+var _consolidateListNodes2 = _interopRequireDefault(_consolidateListNodes);
+
 var _nullthrows = require('nullthrows');
 
 var _nullthrows2 = _interopRequireDefault(_nullthrows);
@@ -60,19 +64,18 @@ function toggleList(tr, schema, listNodeType) {
   } else if (heading && (0, _prosemirrorUtils.findParentNodeOfType)(heading)(fromSelection)) {
     tr = wrapNodesWithList(tr, schema, listNodeType);
   }
-
   return tr;
 }
 
 function unwrapNodesFromList(tr, schema, listNodePos, unwrapParagraphNode) {
   return (0, _transformAndPreserveTextSelection2.default)(tr, schema, function (memo) {
-    return unwrapNodesFromListInternal(memo, listNodePos, unwrapParagraphNode);
+    return (0, _consolidateListNodes2.default)(unwrapNodesFromListInternal(memo, listNodePos, unwrapParagraphNode));
   });
 }
 
 function wrapNodesWithList(tr, schema, listNodeType) {
   return (0, _transformAndPreserveTextSelection2.default)(tr, schema, function (memo) {
-    return wrapNodesWithListInternal(memo, listNodeType);
+    return (0, _consolidateListNodes2.default)(wrapNodesWithListInternal(memo, listNodeType));
   });
 }
 

--- a/dist/toggleList.js.flow
+++ b/dist/toggleList.js.flow
@@ -1,5 +1,6 @@
 // @flow
 
+import consolidateListNodes from './consolidateListNodes';
 import nullthrows from 'nullthrows';
 import {Fragment, Node, NodeType, Schema} from 'prosemirror-model';
 import {TextSelection} from 'prosemirror-state';
@@ -35,7 +36,6 @@ export default function toggleList(
   } else if (heading && findParentNodeOfType(heading)(fromSelection)) {
     tr = wrapNodesWithList(tr, schema, listNodeType);
   }
-
   return tr;
 }
 
@@ -46,7 +46,9 @@ export function unwrapNodesFromList(
   unwrapParagraphNode?: ?(Node) => Node
 ): Transform {
   return transformAndPreserveTextSelection(tr, schema, memo => {
-    return unwrapNodesFromListInternal(memo, listNodePos, unwrapParagraphNode);
+    return consolidateListNodes(
+      unwrapNodesFromListInternal(memo, listNodePos, unwrapParagraphNode)
+    );
   });
 }
 
@@ -56,7 +58,7 @@ function wrapNodesWithList(
   listNodeType: NodeType
 ): Transform {
   return transformAndPreserveTextSelection(tr, schema, memo => {
-    return wrapNodesWithListInternal(memo, listNodeType);
+    return consolidateListNodes(wrapNodesWithListInternal(memo, listNodeType));
   });
 }
 

--- a/dist/ui/czi-bullet-list.css
+++ b/dist/ui/czi-bullet-list.css
@@ -1,8 +1,3 @@
-/* For MS-Edge 16+, Chrome, Safari, Firefox */
-.ProseMirror ul {
-  counter-reset: czi-bullet-counter 0;
-}
-
 .ProseMirror ul li::before {
   /* Default bullet style to "disc" */
   content: '\2022\2009';

--- a/dist/ui/czi-list.css
+++ b/dist/ui/czi-list.css
@@ -13,7 +13,6 @@
    * https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
    */
   column-span: all;
-  counter-reset: none;
   display: flow-root;
   list-style-type: none;
   margin: 0;

--- a/dist/ui/czi-ordered-list.css
+++ b/dist/ui/czi-ordered-list.css
@@ -13,7 +13,6 @@ html {
   --czi-counter-name: czi-counter-0;
   --czi-list-style-type: decimal;
   --czi-counter-reset: 0;
-
   counter-reset: none;
 }
 

--- a/dist/ui/czi-ordered-list.css
+++ b/dist/ui/czi-ordered-list.css
@@ -1,16 +1,28 @@
+html {
+  counter-reset:
+    czi-counter-0 czi-counter-1 czi-counter-2 czi-counter-3
+    czi-counter-4 czi-counter-5 czi-counter-6 czi-counter-7;
+}
+
 /* For MS-Edge 16+, Chrome, Safari, Firefox */
 .ProseMirror ol {
   --czi-counter-name: czi-counter-0;
   --czi-list-style-type: decimal;
   --czi-counter-reset: 0;
+
+  counter-reset: none;
 }
 
 .ProseMirror ol > li {
   counter-increment: var(--czi-counter-name);
 }
 
-.ProseMirror ol > li:first-child {
+.ProseMirror ol:not([data-counter-reset='none']) {
   counter-reset: var(--czi-counter-name) var(--czi-counter-reset);
+}
+
+.ProseMirror ol[data-counter-reset='none'] {
+  counter-reset: none;
 }
 
 .ProseMirror ol > li::before {

--- a/dist/ui/czi-ordered-list.css
+++ b/dist/ui/czi-ordered-list.css
@@ -1,6 +1,6 @@
 html {
-  counter-reset:
-    czi-counter-0 czi-counter-1 czi-counter-2 czi-counter-3
+  /* This sets up the initial counter values to `0`. */
+  counter-reset: czi-counter-0 czi-counter-1 czi-counter-2 czi-counter-3
     czi-counter-4 czi-counter-5 czi-counter-6 czi-counter-7;
 }
 
@@ -9,7 +9,6 @@ html {
   --czi-counter-name: czi-counter-0;
   --czi-list-style-type: decimal;
   --czi-counter-reset: 0;
-
   counter-reset: none;
 }
 

--- a/dist/ui/czi-ordered-list.css
+++ b/dist/ui/czi-ordered-list.css
@@ -1,7 +1,6 @@
 html {
   /* This sets up the initial counter values to `0`. */
-  counter-reset:
-    czi-counter-0 czi-counter-1 czi-counter-2 czi-counter-3
+  counter-reset: czi-counter-0 czi-counter-1 czi-counter-2 czi-counter-3
     czi-counter-4 czi-counter-5 czi-counter-6 czi-counter-7;
 }
 
@@ -10,7 +9,6 @@ html {
   --czi-counter-name: czi-counter-0;
   --czi-list-style-type: decimal;
   --czi-counter-reset: 0;
-
   counter-reset: none;
 }
 

--- a/dist/ui/czi-ordered-list.css
+++ b/dist/ui/czi-ordered-list.css
@@ -4,7 +4,8 @@ html {
    * For now, `ParagraphNodeSpec` only allows 7 indentation levels
    * (src/ParagraphNodeSpec.js) so this defines 7 variables.
    */
-  counter-reset: czi-counter-0 czi-counter-1 czi-counter-2 czi-counter-3
+  counter-reset:
+    czi-counter-0 czi-counter-1 czi-counter-2 czi-counter-3
     czi-counter-4 czi-counter-5 czi-counter-6 czi-counter-7;
 }
 
@@ -13,6 +14,7 @@ html {
   --czi-counter-name: czi-counter-0;
   --czi-list-style-type: decimal;
   --czi-counter-reset: 0;
+
   counter-reset: none;
 }
 

--- a/dist/ui/czi-ordered-list.css
+++ b/dist/ui/czi-ordered-list.css
@@ -1,5 +1,9 @@
 html {
-  /* This sets up the initial counter values to `0`. */
+  /*
+   * This sets up the initial counter values to `0`.
+   * For now, `ParagraphNodeSpec` only allows 7 indentation levels
+   * (src/ParagraphNodeSpec.js) so this defines 7 variables.
+   */
   counter-reset: czi-counter-0 czi-counter-1 czi-counter-2 czi-counter-3
     czi-counter-4 czi-counter-5 czi-counter-6 czi-counter-7;
 }
@@ -9,6 +13,7 @@ html {
   --czi-counter-name: czi-counter-0;
   --czi-list-style-type: decimal;
   --czi-counter-reset: 0;
+
   counter-reset: none;
 }
 

--- a/dist/ui/czi-ordered-list.css
+++ b/dist/ui/czi-ordered-list.css
@@ -1,6 +1,7 @@
 html {
   /* This sets up the initial counter values to `0`. */
-  counter-reset: czi-counter-0 czi-counter-1 czi-counter-2 czi-counter-3
+  counter-reset:
+    czi-counter-0 czi-counter-1 czi-counter-2 czi-counter-3
     czi-counter-4 czi-counter-5 czi-counter-6 czi-counter-7;
 }
 
@@ -9,6 +10,7 @@ html {
   --czi-counter-name: czi-counter-0;
   --czi-list-style-type: decimal;
   --czi-counter-reset: 0;
+
   counter-reset: none;
 }
 

--- a/src/OrderedListNodeSpec.js
+++ b/src/OrderedListNodeSpec.js
@@ -17,7 +17,7 @@ const OrderedListNodeSpec: NodeSpec = {
     counterReset: {default: null},
     indent: {default: MIN_INDENT_LEVEL},
     listStyleType: {default: null},
-    start: {default: null},
+    start: {default: 1},
   },
   group: 'block',
   content: LIST_ITEM + '+',
@@ -31,7 +31,7 @@ const OrderedListNodeSpec: NodeSpec = {
 
         const start = dom.hasAttribute('start')
           ? parseInt(dom.getAttribute('start'), 10)
-          : null;
+          : 1;
 
         const indent = dom.hasAttribute(ATTRIBUTE_INDENT)
           ? parseInt(dom.getAttribute(ATTRIBUTE_INDENT), 10)
@@ -59,7 +59,7 @@ const OrderedListNodeSpec: NodeSpec = {
       attrs[ATTRIBUTE_LIST_STYLE_TYPE] = listStyleType;
     }
 
-    if (start !== 1 && start !== null) {
+    if (start !== 1) {
       attrs.start = start;
     }
 
@@ -74,8 +74,8 @@ const OrderedListNodeSpec: NodeSpec = {
 
     attrs.style =
       `--czi-counter-name: ${cssCounterName};` +
-      `--czi-list-style-type: ${htmlListStyleType}` +
-      `--czi-counter-reset: ${start - 1};`;
+      `--czi-counter-reset: ${start - 1};` +
+      `--czi-list-style-type: ${htmlListStyleType}`;
 
     attrs.type = htmlListStyleType;
 

--- a/src/OrderedListNodeSpec.js
+++ b/src/OrderedListNodeSpec.js
@@ -8,14 +8,16 @@ import {ATTRIBUTE_INDENT, MIN_INDENT_LEVEL} from './ParagraphNodeSpec';
 
 import type {NodeSpec} from './Types';
 
+const ATTRIBUTE_COUNTER_RESET = 'data-counter-reset';
 const AUTO_LIST_STYLE_TYPES = ['decimal', 'lower-alpha', 'lower-roman'];
 
 const OrderedListNodeSpec: NodeSpec = {
   attrs: {
-    id: {default: 1},
+    id: {default: null},
+    counterReset: {default: null},
     indent: {default: MIN_INDENT_LEVEL},
     listStyleType: {default: null},
-    start: {default: 1},
+    start: {default: null},
   },
   group: 'block',
   content: LIST_ITEM + '+',
@@ -24,16 +26,19 @@ const OrderedListNodeSpec: NodeSpec = {
       tag: 'ol',
       getAttrs(dom: HTMLElement) {
         const listStyleType = dom.getAttribute(ATTRIBUTE_LIST_STYLE_TYPE);
+        const counterReset =
+          dom.getAttribute(ATTRIBUTE_COUNTER_RESET) || undefined;
 
         const start = dom.hasAttribute('start')
           ? parseInt(dom.getAttribute('start'), 10)
-          : 1;
+          : null;
 
         const indent = dom.hasAttribute(ATTRIBUTE_INDENT)
           ? parseInt(dom.getAttribute(ATTRIBUTE_INDENT), 10)
           : MIN_INDENT_LEVEL;
 
         return {
+          counterReset,
           indent,
           listStyleType,
           start,
@@ -42,16 +47,19 @@ const OrderedListNodeSpec: NodeSpec = {
     },
   ],
   toDOM(node: Node) {
-    const {start, indent, listStyleType} = node.attrs;
+    const {start, indent, listStyleType, counterReset} = node.attrs;
     const attrs: Object = {
       [ATTRIBUTE_INDENT]: indent,
     };
+    if (counterReset === 'none') {
+      attrs[ATTRIBUTE_COUNTER_RESET] = counterReset;
+    }
 
     if (listStyleType) {
       attrs[ATTRIBUTE_LIST_STYLE_TYPE] = listStyleType;
     }
 
-    if (start !== MIN_INDENT_LEVEL) {
+    if (start !== 1 && start !== null) {
       attrs.start = start;
     }
 
@@ -66,8 +74,8 @@ const OrderedListNodeSpec: NodeSpec = {
 
     attrs.style =
       `--czi-counter-name: ${cssCounterName};` +
-      `--czi-counter-reset: ${start - 1};` +
-      `--czi-list-style-type: ${htmlListStyleType}`;
+      `--czi-list-style-type: ${htmlListStyleType}` +
+      `--czi-counter-reset: ${start - 1};`;
 
     attrs.type = htmlListStyleType;
 

--- a/src/consolidateListNodes.js
+++ b/src/consolidateListNodes.js
@@ -82,7 +82,7 @@ function linkOrderedListCounters(tr: Transform): Transform {
   tr.doc.nodesBetween(from, to, (node, pos, parentNode) => {
     let willTraverseNodeChildren = true;
     if (isListNode(node)) {
-      // List Node can't be nested, no need to travere its children.
+      // List Node can't be nested, no need to traverse its children.
       willTraverseNodeChildren = false;
       const indent = node.attrs.indent || 0;
       const start = node.attrs.start || 1;

--- a/src/consolidateListNodes.js
+++ b/src/consolidateListNodes.js
@@ -69,7 +69,7 @@ export default function consolidateListNodes(tr: Transform): Transform {
  *   3. EEE
  *   4. FFF
  *   --------
- * This means that the t1st and the 3rd lists are linked.
+ * This means that the 1st and the 3rd lists are linked.
  */
 function linkOrderedListCounters(tr: Transform): Transform {
   const from = 1;
@@ -151,7 +151,7 @@ function linkOrderedListCounters(tr: Transform): Transform {
       }
       listsBefore.unshift({parentNode, indent, node});
     } else {
-      // Not traversing withing any list node. No lists need to be updated.
+      // Not traversing within any list node. No lists need to be updated.
       listsBefore = null;
     }
     return willTraverseNodeChildren;

--- a/src/consolidateListNodes.js
+++ b/src/consolidateListNodes.js
@@ -1,5 +1,6 @@
 // @flow
 
+import isOrderedListNode from './isOrderedListNode';
 import isListNode from './isListNode';
 import {Fragment} from 'prosemirror-model';
 import {Node} from 'prosemirror-model';
@@ -11,6 +12,13 @@ type JointInfo = {
   deleteTo: number,
   firstListNodePos: number,
   insertAt: number,
+};
+
+type NodeInfo = {
+  node: Node,
+  pos: number,
+  parentNode: ?Node,
+  prev: ?NodeInfo,
 };
 
 // Consolidate list nodes.
@@ -35,8 +43,140 @@ export default function consolidateListNodes(tr: Transform): Transform {
       tr = tr.insert(insertAt, content);
       prevJointInfo = jointInfo;
     } else {
+      tr = linkOrderedListCounters(tr);
       break;
     }
+  }
+  return tr;
+}
+
+/**
+ * This ensures that the adjacent ordered lists within the same indent level
+ * share the same counter.
+ *
+ * For example, the following three lists:
+ *   --------
+ *   1. AAA
+ *   2. BBB
+ *   --------
+ *     a. CCC
+ *     d. DDD
+ *   --------
+ *   1. EEE
+ *   2. FFF
+ *   --------
+ * Will transform into
+ *   --------
+ *   1. AAA
+ *   2. BBB
+ *   --------
+ *     a. CCC
+ *     d. DDD
+ *   --------
+ *   3. EEE
+ *   4. FFF
+ *   --------
+ * This means that the t1st and the 3rd lists are linked.
+ */
+function linkOrderedListCounters(tr: Transform): Transform {
+  const from = 1;
+  const to = tr.doc.nodeSize - 2;
+  if (from >= to) {
+    return tr;
+  }
+
+  let listsBefore = null;
+  tr.doc.nodesBetween(from, to, (node, pos, parentNode) => {
+    let willTraverseNodeChildren = true;
+    if (isListNode(node)) {
+      // List Node can't be nested, no need to travere its children.
+      willTraverseNodeChildren = false;
+      const indent = node.attrs.indent || 0;
+      const start = node.attrs.start || 1;
+      if (listsBefore) {
+        if (start === 1 && isOrderedListNode(node)) {
+          // Look backward until we could find another ordered list node to
+          // link with.
+          let counterIsLinked;
+          listsBefore.some((list, index) => {
+            if (list.node.type !== node.type && list.indent === indent) {
+              // This encounters different type of list node (e.g a bullet
+              // list node), we need to restart the counter.
+              // ------
+              // 1. AAA
+              // 2. BBB
+              // ------
+              // -. CCC
+              // -. DDD
+              // ------
+              // 1. DDD <- Counter restarts here.
+              // 2. EEE
+              // ------
+              counterIsLinked = false;
+              return true;
+            } else if (list.indent < indent) {
+              // This encounters an ordered list node that has less indent.
+              // we need to restart the counter.
+              // ------
+              // 1. AAA
+              // 2. BBB
+              // ------
+              //   1. DDD <- Counter restarts here.
+              //   2. EEE
+              // ------
+              counterIsLinked = false;
+              return true;
+            } else if (list.indent === indent) {
+              // This encounters an ordered list node that has same indent.
+              // Do not Restart the counter.
+              // ------
+              // 1. AAA
+              // 2. BBB
+              // ------
+              // 3. DDD <- Counter continues here.
+              // 4. EEE
+              // ------
+              counterIsLinked = true;
+              return true;
+            }
+            return false;
+          });
+
+          if (counterIsLinked !== undefined) {
+            tr = setCounterLinked(tr, pos, counterIsLinked);
+          }
+        }
+      } else {
+        // Found the first list.
+        // ------
+        // 1. AAA <- Counter restarts here.
+        // 2. BBB
+        listsBefore = [];
+        if (isOrderedListNode(node)) {
+          tr = setCounterLinked(tr, pos, false);
+        }
+      }
+      listsBefore.unshift({parentNode, indent, node});
+    } else {
+      // Not traversing withing any list node. No lists need to be updated.
+      listsBefore = null;
+    }
+    return willTraverseNodeChildren;
+  });
+  return tr;
+}
+
+function setCounterLinked(
+  tr: Transform,
+  pos: number,
+  linked: boolean
+): Transform {
+  const node = tr.doc.nodeAt(pos);
+  const currentValue = node.attrs.counterReset || null;
+  const nextValue = linked ? 'none' : null;
+  if (nextValue !== currentValue) {
+    const nodeAttrs = {...node.attrs, counterReset: nextValue};
+    tr = tr.setNodeMarkup(pos, node.type, nodeAttrs, node.marks);
   }
   return tr;
 }

--- a/src/consolidateListNodes.js
+++ b/src/consolidateListNodes.js
@@ -14,13 +14,6 @@ type JointInfo = {
   insertAt: number,
 };
 
-type NodeInfo = {
-  node: Node,
-  pos: number,
-  parentNode: ?Node,
-  prev: ?NodeInfo,
-};
-
 // Consolidate list nodes.
 // All adjacent list nodes with the same list type and indent level will be
 // joined into one list node.

--- a/src/toggleList.js
+++ b/src/toggleList.js
@@ -1,5 +1,6 @@
 // @flow
 
+import consolidateListNodes from './consolidateListNodes';
 import nullthrows from 'nullthrows';
 import {Fragment, Node, NodeType, Schema} from 'prosemirror-model';
 import {TextSelection} from 'prosemirror-state';
@@ -35,7 +36,6 @@ export default function toggleList(
   } else if (heading && findParentNodeOfType(heading)(fromSelection)) {
     tr = wrapNodesWithList(tr, schema, listNodeType);
   }
-
   return tr;
 }
 
@@ -46,7 +46,9 @@ export function unwrapNodesFromList(
   unwrapParagraphNode?: ?(Node) => Node
 ): Transform {
   return transformAndPreserveTextSelection(tr, schema, memo => {
-    return unwrapNodesFromListInternal(memo, listNodePos, unwrapParagraphNode);
+    return consolidateListNodes(
+      unwrapNodesFromListInternal(memo, listNodePos, unwrapParagraphNode)
+    );
   });
 }
 
@@ -56,7 +58,7 @@ function wrapNodesWithList(
   listNodeType: NodeType
 ): Transform {
   return transformAndPreserveTextSelection(tr, schema, memo => {
-    return wrapNodesWithListInternal(memo, listNodeType);
+    return consolidateListNodes(wrapNodesWithListInternal(memo, listNodeType));
   });
 }
 

--- a/src/ui/czi-bullet-list.css
+++ b/src/ui/czi-bullet-list.css
@@ -1,8 +1,3 @@
-/* For MS-Edge 16+, Chrome, Safari, Firefox */
-.ProseMirror ul {
-  counter-reset: czi-bullet-counter 0;
-}
-
 .ProseMirror ul li::before {
   /* Default bullet style to "disc" */
   content: '\2022\2009';

--- a/src/ui/czi-list.css
+++ b/src/ui/czi-list.css
@@ -13,7 +13,6 @@
    * https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
    */
   column-span: all;
-  counter-reset: none;
   display: flow-root;
   list-style-type: none;
   margin: 0;

--- a/src/ui/czi-ordered-list.css
+++ b/src/ui/czi-ordered-list.css
@@ -13,7 +13,6 @@ html {
   --czi-counter-name: czi-counter-0;
   --czi-list-style-type: decimal;
   --czi-counter-reset: 0;
-
   counter-reset: none;
 }
 

--- a/src/ui/czi-ordered-list.css
+++ b/src/ui/czi-ordered-list.css
@@ -1,16 +1,28 @@
+html {
+  counter-reset:
+    czi-counter-0 czi-counter-1 czi-counter-2 czi-counter-3
+    czi-counter-4 czi-counter-5 czi-counter-6 czi-counter-7;
+}
+
 /* For MS-Edge 16+, Chrome, Safari, Firefox */
 .ProseMirror ol {
   --czi-counter-name: czi-counter-0;
   --czi-list-style-type: decimal;
   --czi-counter-reset: 0;
+
+  counter-reset: none;
 }
 
 .ProseMirror ol > li {
   counter-increment: var(--czi-counter-name);
 }
 
-.ProseMirror ol > li:first-child {
+.ProseMirror ol:not([data-counter-reset='none']) {
   counter-reset: var(--czi-counter-name) var(--czi-counter-reset);
+}
+
+.ProseMirror ol[data-counter-reset='none'] {
+  counter-reset: none;
 }
 
 .ProseMirror ol > li::before {

--- a/src/ui/czi-ordered-list.css
+++ b/src/ui/czi-ordered-list.css
@@ -1,6 +1,6 @@
 html {
-  counter-reset:
-    czi-counter-0 czi-counter-1 czi-counter-2 czi-counter-3
+  /* This sets up the initial counter values to `0`. */
+  counter-reset: czi-counter-0 czi-counter-1 czi-counter-2 czi-counter-3
     czi-counter-4 czi-counter-5 czi-counter-6 czi-counter-7;
 }
 
@@ -9,7 +9,6 @@ html {
   --czi-counter-name: czi-counter-0;
   --czi-list-style-type: decimal;
   --czi-counter-reset: 0;
-
   counter-reset: none;
 }
 

--- a/src/ui/czi-ordered-list.css
+++ b/src/ui/czi-ordered-list.css
@@ -1,7 +1,6 @@
 html {
   /* This sets up the initial counter values to `0`. */
-  counter-reset:
-    czi-counter-0 czi-counter-1 czi-counter-2 czi-counter-3
+  counter-reset: czi-counter-0 czi-counter-1 czi-counter-2 czi-counter-3
     czi-counter-4 czi-counter-5 czi-counter-6 czi-counter-7;
 }
 
@@ -10,7 +9,6 @@ html {
   --czi-counter-name: czi-counter-0;
   --czi-list-style-type: decimal;
   --czi-counter-reset: 0;
-
   counter-reset: none;
 }
 

--- a/src/ui/czi-ordered-list.css
+++ b/src/ui/czi-ordered-list.css
@@ -4,7 +4,8 @@ html {
    * For now, `ParagraphNodeSpec` only allows 7 indentation levels
    * (src/ParagraphNodeSpec.js) so this defines 7 variables.
    */
-  counter-reset: czi-counter-0 czi-counter-1 czi-counter-2 czi-counter-3
+  counter-reset:
+    czi-counter-0 czi-counter-1 czi-counter-2 czi-counter-3
     czi-counter-4 czi-counter-5 czi-counter-6 czi-counter-7;
 }
 
@@ -13,6 +14,7 @@ html {
   --czi-counter-name: czi-counter-0;
   --czi-list-style-type: decimal;
   --czi-counter-reset: 0;
+
   counter-reset: none;
 }
 

--- a/src/ui/czi-ordered-list.css
+++ b/src/ui/czi-ordered-list.css
@@ -1,5 +1,9 @@
 html {
-  /* This sets up the initial counter values to `0`. */
+  /*
+   * This sets up the initial counter values to `0`.
+   * For now, `ParagraphNodeSpec` only allows 7 indentation levels
+   * (src/ParagraphNodeSpec.js) so this defines 7 variables.
+   */
   counter-reset: czi-counter-0 czi-counter-1 czi-counter-2 czi-counter-3
     czi-counter-4 czi-counter-5 czi-counter-6 czi-counter-7;
 }
@@ -9,6 +13,7 @@ html {
   --czi-counter-name: czi-counter-0;
   --czi-list-style-type: decimal;
   --czi-counter-reset: 0;
+
   counter-reset: none;
 }
 

--- a/src/ui/czi-ordered-list.css
+++ b/src/ui/czi-ordered-list.css
@@ -1,6 +1,7 @@
 html {
   /* This sets up the initial counter values to `0`. */
-  counter-reset: czi-counter-0 czi-counter-1 czi-counter-2 czi-counter-3
+  counter-reset:
+    czi-counter-0 czi-counter-1 czi-counter-2 czi-counter-3
     czi-counter-4 czi-counter-5 czi-counter-6 czi-counter-7;
 }
 
@@ -9,6 +10,7 @@ html {
   --czi-counter-name: czi-counter-0;
   --czi-list-style-type: decimal;
   --czi-counter-reset: 0;
+
   counter-reset: none;
 }
 


### PR DESCRIPTION
## Summary 

Ordered list that are physically separated but visually related around maintain consistent order number.

---

#### Before

Three lists A, B, and C. The list B has extra indentation level 1. 

```
---
1. AA
2. AA
---
  a. BB
  b. BB
---
1. CC
2. CC
----
```

#### After

Three lists A, B, and C. The list B has extra indentation level 1. 

```
---
1. AA
2. AA
---
  a. BB
  b. BB
---
3. CC <== This list starts with 3, not 1.
4. CC
----
```

---

## Details:

People often use indentation as a way to represent hierarchical relations between multiple lists.
For instance:

#### Before

Four lists A, B, C and D. The lists B and C has extra indentation.

```
---
1. AA
2. AA
---
  a. BB
  b. BB
---
    i. CC
    ii. CC
---
  a. DD
  b. DD
---
1. EE 
2. EE
----
```
#### After

Should be 

```
---
1. AA
2. AA
---
  a. BB
  b. BB
---
    i. CC
    ii. CC
---
  c. DD <== This list starts with "c", not "a".
  d. DD
---
3. EE  <== This list starts with 3, not 1.
4. EE
----
```

---

#### DEMO


![000reorder](https://user-images.githubusercontent.com/1504439/58294874-33833200-7d81-11e9-8751-cee7c412614e.gif)
