### PR TITLE
Fix: Element with custom font size should compute its own line-height correctly.

### DIFF
--- a/dist/FontSizeMarkSpec.js
+++ b/dist/FontSizeMarkSpec.js
@@ -23,8 +23,12 @@ var FontSizeMarkSpec = {
   toDOM: function toDOM(node) {
     var pt = node.attrs.pt;
 
-    var style = pt ? 'font-size: ' + pt + 'pt' : '';
-    return ['span', { style: style }, 0];
+    var domAttrs = pt ? {
+      style: 'font-size: ' + pt + 'pt;',
+      class: 'czi-font-size-mark'
+    } : null;
+
+    return ['span', domAttrs, 0];
   }
 };
 

--- a/dist/FontSizeMarkSpec.js.flow
+++ b/dist/FontSizeMarkSpec.js.flow
@@ -20,8 +20,14 @@ const FontSizeMarkSpec: MarkSpec = {
   ],
   toDOM(node: Node) {
     const {pt} = node.attrs;
-    const style = pt ? `font-size: ${pt}pt` : '';
-    return ['span', {style}, 0];
+    const domAttrs = pt
+      ? {
+          style: `font-size: ${pt}pt;`,
+          class: 'czi-font-size-mark',
+        }
+      : null;
+
+    return ['span', domAttrs, 0];
   },
 };
 

--- a/dist/ParagraphNodeSpec.js
+++ b/dist/ParagraphNodeSpec.js
@@ -103,7 +103,11 @@ function toDOM(node) {
   }
 
   if (lineSpacing) {
-    style += 'line-height: ' + (0, _toCSSLineSpacing2.default)(lineSpacing) + ';';
+    var cssLineSpacing = (0, _toCSSLineSpacing2.default)(lineSpacing);
+    style += 'line-height: ' + cssLineSpacing + ';' + (
+    // This creates the local css variable `--czi-content-line-height`
+    // that its children may apply.
+    '--czi-content-line-height: ' + cssLineSpacing);
   }
 
   if (paddingTop && !EMPTY_CSS_VALUE.has(paddingTop)) {

--- a/dist/ParagraphNodeSpec.js.flow
+++ b/dist/ParagraphNodeSpec.js.flow
@@ -81,7 +81,12 @@ function toDOM(node: Node): Array<any> {
   }
 
   if (lineSpacing) {
-    style += `line-height: ${toCSSLineSpacing(lineSpacing)};`;
+    const cssLineSpacing = toCSSLineSpacing(lineSpacing);
+    style +=
+      `line-height: ${cssLineSpacing};` +
+      // This creates the local css variable `--czi-content-line-height`
+      // that its children may apply.
+      `--czi-content-line-height: ${cssLineSpacing}`;
   }
 
   if (paddingTop && !EMPTY_CSS_VALUE.has(paddingTop)) {

--- a/dist/ui/czi-editor.css
+++ b/dist/ui/czi-editor.css
@@ -176,3 +176,7 @@
   page-break-before: always;
   visibility: hidden;
 }
+
+.ProseMirror .czi-font-size-mark {
+  line-height: var(--czi-content-line-height);
+}

--- a/src/FontSizeMarkSpec.js
+++ b/src/FontSizeMarkSpec.js
@@ -20,8 +20,14 @@ const FontSizeMarkSpec: MarkSpec = {
   ],
   toDOM(node: Node) {
     const {pt} = node.attrs;
-    const style = pt ? `font-size: ${pt}pt` : '';
-    return ['span', {style}, 0];
+    const domAttrs = pt
+      ? {
+          style: `font-size: ${pt}pt;`,
+          class: 'czi-font-size-mark',
+        }
+      : null;
+
+    return ['span', domAttrs, 0];
   },
 };
 

--- a/src/ParagraphNodeSpec.js
+++ b/src/ParagraphNodeSpec.js
@@ -81,7 +81,12 @@ function toDOM(node: Node): Array<any> {
   }
 
   if (lineSpacing) {
-    style += `line-height: ${toCSSLineSpacing(lineSpacing)};`;
+    const cssLineSpacing = toCSSLineSpacing(lineSpacing);
+    style +=
+      `line-height: ${cssLineSpacing};` +
+      // This creates the local css variable `--czi-content-line-height`
+      // that its children may apply.
+      `--czi-content-line-height: ${cssLineSpacing}`;
   }
 
   if (paddingTop && !EMPTY_CSS_VALUE.has(paddingTop)) {

--- a/src/ui/czi-editor.css
+++ b/src/ui/czi-editor.css
@@ -176,3 +176,7 @@
   page-break-before: always;
   visibility: hidden;
 }
+
+.ProseMirror .czi-font-size-mark {
+  line-height: var(--czi-content-line-height);
+}


### PR DESCRIPTION
In editor, the CSS `line-height` is applied at the block (e.g. a paragraph) level and `font-size` is applied at inline (e.g. a span) level.

```
<p style="line-height: 200%">
  foo <span style="font-size: 20pt">bar</span>
</p>
```

and there causes a but that the  inline  element with custom font-size does not get its line-height rendered properly because it uses the same line-height as the containing block element does instead of computing it own line-height.

This diff ensures that element with custom font size will compute its own line-height correctly.
 

# Test Plan

- select some paragraph
- set line spacing to "double"
- select some text
- set font-size to large font size.

## before

![image](https://user-images.githubusercontent.com/1504439/58345895-5576c600-7e0e-11e9-8ac7-3bb28e9d6627.png)


## after

![image](https://user-images.githubusercontent.com/1504439/58345916-5f002e00-7e0e-11e9-9cf4-0f3c39d80ef8.png)
