### PR TITLE
Allow split lists to share the same counter variable.

### DIFF
--- a/dist/OrderedListNodeSpec.js
+++ b/dist/OrderedListNodeSpec.js
@@ -21,6 +21,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 var babelPluginFlowReactPropTypes_proptype_NodeSpec = require('./Types').babelPluginFlowReactPropTypes_proptype_NodeSpec || require('prop-types').any;
 
 var ATTRIBUTE_COUNTER_RESET = 'data-counter-reset';
+var ATTRIBUTE_FOLLOWING = 'data-following';
 var AUTO_LIST_STYLE_TYPES = ['decimal', 'lower-alpha', 'lower-roman'];
 
 var OrderedListNodeSpec = {
@@ -28,7 +29,9 @@ var OrderedListNodeSpec = {
     id: { default: null },
     counterReset: { default: null },
     indent: { default: _ParagraphNodeSpec.MIN_INDENT_LEVEL },
+    following: { default: null },
     listStyleType: { default: null },
+    name: { default: null },
     start: { default: 1 }
   },
   group: 'block',
@@ -43,10 +46,16 @@ var OrderedListNodeSpec = {
 
       var indent = dom.hasAttribute(_ParagraphNodeSpec.ATTRIBUTE_INDENT) ? parseInt(dom.getAttribute(_ParagraphNodeSpec.ATTRIBUTE_INDENT), 10) : _ParagraphNodeSpec.MIN_INDENT_LEVEL;
 
+      var name = dom.getAttribute('name') || undefined;
+
+      var following = dom.getAttribute(ATTRIBUTE_FOLLOWING) || undefined;
+
       return {
         counterReset: counterReset,
+        following: following,
         indent: indent,
         listStyleType: listStyleType,
+        name: name,
         start: start
       };
     }
@@ -56,11 +65,18 @@ var OrderedListNodeSpec = {
         start = _node$attrs.start,
         indent = _node$attrs.indent,
         listStyleType = _node$attrs.listStyleType,
-        counterReset = _node$attrs.counterReset;
+        counterReset = _node$attrs.counterReset,
+        following = _node$attrs.following,
+        name = _node$attrs.name;
 
     var attrs = (0, _defineProperty3.default)({}, _ParagraphNodeSpec.ATTRIBUTE_INDENT, indent);
+
     if (counterReset === 'none') {
       attrs[ATTRIBUTE_COUNTER_RESET] = counterReset;
+    }
+
+    if (following) {
+      attrs[ATTRIBUTE_FOLLOWING] = following;
     }
 
     if (listStyleType) {
@@ -69,6 +85,10 @@ var OrderedListNodeSpec = {
 
     if (start !== 1) {
       attrs.start = start;
+    }
+
+    if (name) {
+      attrs.name = name;
     }
 
     var htmlListStyleType = listStyleType;

--- a/dist/OrderedListNodeSpec.js.flow
+++ b/dist/OrderedListNodeSpec.js.flow
@@ -9,6 +9,7 @@ import {ATTRIBUTE_INDENT, MIN_INDENT_LEVEL} from './ParagraphNodeSpec';
 import type {NodeSpec} from './Types';
 
 const ATTRIBUTE_COUNTER_RESET = 'data-counter-reset';
+const ATTRIBUTE_FOLLOWING = 'data-following';
 const AUTO_LIST_STYLE_TYPES = ['decimal', 'lower-alpha', 'lower-roman'];
 
 const OrderedListNodeSpec: NodeSpec = {
@@ -16,7 +17,9 @@ const OrderedListNodeSpec: NodeSpec = {
     id: {default: null},
     counterReset: {default: null},
     indent: {default: MIN_INDENT_LEVEL},
+    following: {default: null},
     listStyleType: {default: null},
+    name: {default: null},
     start: {default: 1},
   },
   group: 'block',
@@ -37,22 +40,40 @@ const OrderedListNodeSpec: NodeSpec = {
           ? parseInt(dom.getAttribute(ATTRIBUTE_INDENT), 10)
           : MIN_INDENT_LEVEL;
 
+        const name = dom.getAttribute('name') || undefined;
+
+        const following = dom.getAttribute(ATTRIBUTE_FOLLOWING) || undefined;
+
         return {
           counterReset,
+          following,
           indent,
           listStyleType,
+          name,
           start,
         };
       },
     },
   ],
   toDOM(node: Node) {
-    const {start, indent, listStyleType, counterReset} = node.attrs;
+    const {
+      start,
+      indent,
+      listStyleType,
+      counterReset,
+      following,
+      name,
+    } = node.attrs;
     const attrs: Object = {
       [ATTRIBUTE_INDENT]: indent,
     };
+
     if (counterReset === 'none') {
       attrs[ATTRIBUTE_COUNTER_RESET] = counterReset;
+    }
+
+    if (following) {
+      attrs[ATTRIBUTE_FOLLOWING] = following;
     }
 
     if (listStyleType) {
@@ -61,6 +82,10 @@ const OrderedListNodeSpec: NodeSpec = {
 
     if (start !== 1) {
       attrs.start = start;
+    }
+
+    if (name) {
+      attrs.name = name;
     }
 
     let htmlListStyleType = listStyleType;

--- a/dist/consolidateListNodes.js
+++ b/dist/consolidateListNodes.js
@@ -188,7 +188,7 @@ function linkOrderedListCounters(tr) {
           }
         }
       } else {
-        // Found the first list for a new Lists Island.
+        // Found the first list among a new Lists Island.
         // ------
         // 1. AAA <- Counter restarts here.
         // 2. BBB

--- a/dist/consolidateListNodes.js.flow
+++ b/dist/consolidateListNodes.js.flow
@@ -14,9 +14,27 @@ type JointInfo = {
   insertAt: number,
 };
 
-// Consolidate list nodes.
-// All adjacent list nodes with the same list type and indent level will be
-// joined into one list node.
+// This function consolidates list nodes among the same "Lists Island".
+//
+// ## Definition of a "Lists Island"
+//   Separate list that are adjacent to each other are grouped as
+//   a "Lists Island".
+//   For example, the following HTML snippets contains two "Lists Island":
+//
+//     <h1>text</h1>
+//     <!-- Lists Island Starts -->
+//     <ul><li>text</li><li>text</li></ul>
+//     <ol><li>text</li><li>text</li></ul>
+//     <!-- Lists Island Ends -->
+//     <p>text</p>
+//     <!-- Lists Island Starts -->
+//     <ul><li>text</li><li>text</li></ul>
+//     <ol><li>text</li><li>text</li></ul>
+//     <!-- Lists Island Ends -->
+//     <p>text</p>
+//
+// List nodes with the same list type and indent level among the same Lists
+// Island will be joined into one list node.
 // Note that this transform may change the current user selection.
 export default function consolidateListNodes(tr: Transform): Transform {
   if (tr.getMeta('dryrun')) {
@@ -44,8 +62,8 @@ export default function consolidateListNodes(tr: Transform): Transform {
 }
 
 /**
- * This ensures that the adjacent ordered lists within the same indent level
- * share the same counter.
+ * This ensures that ordered lists with the same indent level among the same
+ * Lists Island share the same counter.
  *
  * For example, the following three lists:
  *   --------
@@ -78,6 +96,8 @@ function linkOrderedListCounters(tr: Transform): Transform {
     return tr;
   }
 
+  const namedLists = new Set();
+
   let listsBefore = null;
   tr.doc.nodesBetween(from, to, (node, pos, parentNode) => {
     let willTraverseNodeChildren = true;
@@ -86,6 +106,11 @@ function linkOrderedListCounters(tr: Transform): Transform {
       willTraverseNodeChildren = false;
       const indent = node.attrs.indent || 0;
       const start = node.attrs.start || 1;
+      const {name, following} = node.attrs;
+      if (name) {
+        namedLists.add(name);
+      }
+
       if (listsBefore) {
         if (start === 1 && isOrderedListNode(node)) {
           // Look backward until we could find another ordered list node to
@@ -140,13 +165,16 @@ function linkOrderedListCounters(tr: Transform): Transform {
           }
         }
       } else {
-        // Found the first list.
+        // Found the first list for a new Lists Island.
         // ------
         // 1. AAA <- Counter restarts here.
         // 2. BBB
         listsBefore = [];
         if (isOrderedListNode(node)) {
-          tr = setCounterLinked(tr, pos, false);
+          // The list may follow a previous list that is among another Lists
+          // Island. If so, do not reset the list counter.
+          const counterIsLinked = namedLists.has(following);
+          tr = setCounterLinked(tr, pos, counterIsLinked);
         }
       }
       listsBefore.unshift({parentNode, indent, node});

--- a/dist/consolidateListNodes.js.flow
+++ b/dist/consolidateListNodes.js.flow
@@ -165,7 +165,7 @@ function linkOrderedListCounters(tr: Transform): Transform {
           }
         }
       } else {
-        // Found the first list for a new Lists Island.
+        // Found the first list among a new Lists Island.
         // ------
         // 1. AAA <- Counter restarts here.
         // 2. BBB

--- a/dist/splitListItem.js
+++ b/dist/splitListItem.js
@@ -3,13 +3,24 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+
+var _extends2 = require('babel-runtime/helpers/extends');
+
+var _extends3 = _interopRequireDefault(_extends2);
+
 exports.default = splitListItem;
 
 var _prosemirrorModel = require('prosemirror-model');
 
+var _prosemirrorState = require('prosemirror-state');
+
 var _prosemirrorTransform = require('prosemirror-transform');
 
 var _NodeNames = require('./NodeNames');
+
+var _prosemirrorUtils = require('prosemirror-utils');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 // Build a command that splits a non-empty textblock at the top level
 // of a list item by also splitting that list item.
@@ -43,25 +54,33 @@ function splitListItem(tr, schema) {
     // In an empty block. If this is a nested list, the wrapping
     // list item should be split. Otherwise, bail out and let next
     // command handle lifting.
-    if ($from.depth == 2 || $from.node(-3).type !== nodeType || $from.index(-2) != $from.node(-2).childCount - 1) {
-      return tr;
-    }
+    // if (
+    //   $from.depth == 2 ||
+    //   $from.node(-3).type !== nodeType ||
+    //   $from.index(-2) != $from.node(-2).childCount - 1
+    // ) {
+    //   return tr;
+    // }
 
-    var wrap = _prosemirrorModel.Fragment.empty;
-    var keepItem = $from.index(-1) > 0;
-    // Build a fragment containing empty versions of the structure
-    // from the outer list item to the parent node of the cursor
-    for (var d = $from.depth - (keepItem ? 1 : 2); d >= $from.depth - 3; d--) {
-      wrap = _prosemirrorModel.Fragment.from($from.node(d).copy(wrap));
-    }
+    // let wrap = Fragment.empty;
+    // const keepItem = $from.index(-1) > 0;
+    // // Build a fragment containing empty versions of the structure
+    // // from the outer list item to the parent node of the cursor
+    // for (let d = $from.depth - (keepItem ? 1 : 2); d >= $from.depth - 3; d--) {
+    //   wrap = Fragment.from($from.node(d).copy(wrap));
+    // }
 
-    // Add a second list item with an empty default start node
-    wrap = wrap.append(_prosemirrorModel.Fragment.from(nodeType.createAndFill()));
-    tr = tr.replace($from.before(keepItem ? null : -1), $from.after(-3), new _prosemirrorModel.Slice(wrap, keepItem ? 3 : 2, 2));
+    // // Add a second list item with an empty default start node
+    // wrap = wrap.append(Fragment.from(nodeType.createAndFill()));
+    // tr = tr.replace(
+    //   $from.before(keepItem ? null : -1),
+    //   $from.after(-3),
+    //   new Slice(wrap, keepItem ? 3 : 2, 2)
+    // );
 
-    var pos = $from.pos + (keepItem ? 3 : 2);
-    tr = tr.setSelection(selection.constructor.near(tr.doc.resolve(pos)));
-    return tr;
+    // const pos = $from.pos + (keepItem ? 3 : 2);
+    // tr = tr.setSelection(selection.constructor.near(tr.doc.resolve(pos)));
+    return insertParagraphAndSplitBlankListItem(tr, schema);
   }
 
   var nextType = $to.pos == $from.end() ? grandParent.contentMatchAt($from.indexAfter(-1)).defaultType : null;
@@ -73,4 +92,58 @@ function splitListItem(tr, schema) {
   }
 
   return tr.split($from.pos, 2, types);
+}
+
+function insertParagraphAndSplitBlankListItem(tr, schema) {
+  var listItemType = schema.nodes[_NodeNames.LIST_ITEM];
+  var orderedListType = schema.nodes[_NodeNames.ORDERED_LIST];
+  var bulletListType = schema.nodes[_NodeNames.BULLET_LIST];
+  var paragraphType = schema.nodes[_NodeNames.PARAGRAPH];
+  if (!listItemType || !paragraphType) {
+    // Schema does not support the nodes expected.
+    return tr;
+  }
+  var listItemFound = (0, _prosemirrorUtils.findParentNodeOfType)(listItemType)(tr.selection);
+  if (!listItemFound || listItemFound.node.textContent !== '') {
+    // Selection cursor is not inside an empty list item.
+    return tr;
+  }
+
+  var listFound = orderedListType && (0, _prosemirrorUtils.findParentNodeOfType)(orderedListType)(tr.selection) || bulletListType && (0, _prosemirrorUtils.findParentNodeOfType)(bulletListType)(tr.selection);
+
+  if (!listFound) {
+    // Selection isn't inside an list.
+    return tr;
+  }
+
+  var $listItemPos = tr.doc.resolve(listItemFound.pos);
+  var listItemIndex = $listItemPos.index($listItemPos.depth);
+  if (listFound.node.childCount < 3 || listItemIndex < 1 || listItemIndex >= listFound.node.childCount - 1) {
+    // - The list must have at least three list items
+    // - The cursor must be after the first list item and before the last list
+    //   item.
+    // If both conditions don't match, bails out.
+    return tr;
+  }
+
+  var sliceFrom = listItemFound.pos + listItemFound.node.nodeSize;
+  var sliceTo = listFound.pos + listFound.node.nodeSize - 1;
+  var slicedItems = tr.doc.slice(sliceFrom, sliceTo, false);
+
+  var deleteFrom = listItemFound.pos;
+  var deleteTo = listFound.pos + listFound.node.nodeSize;
+  tr = tr.delete(deleteFrom, deleteTo);
+  var sourceListNode = listFound.node;
+  var listAttrs = (0, _extends3.default)({}, sourceListNode.attrs);
+  if (orderedListType === sourceListNode.type) {
+    listAttrs.counterReset = 'none';
+  }
+
+  var insertFrom = deleteFrom + 1;
+  var listNode = sourceListNode.type.create(listAttrs, slicedItems.content);
+  tr = tr.insert(insertFrom, listNode);
+  var paragraph = paragraphType.create({}, _prosemirrorModel.Fragment.empty);
+  tr = tr.insert(insertFrom, paragraph);
+  tr = tr.setSelection(_prosemirrorState.TextSelection.create(tr.doc, insertFrom));
+  return tr;
 }

--- a/dist/splitListItem.js
+++ b/dist/splitListItem.js
@@ -171,7 +171,7 @@ function splitEmptyListItem(tr, schema) {
   }
 
   // We'll split the list into two lists.
-  // the first liust contains the items before the cursor, and the second
+  // the first list contains the items before the cursor, and the second
   // list contains the items after the cursor and the second list will "follow"
   // the first list by sharing the same counter variable.
   var sliceFrom = listItemFound.pos + listItemFound.node.nodeSize;

--- a/dist/splitListItem.js
+++ b/dist/splitListItem.js
@@ -26,8 +26,9 @@ var _prosemirrorUtils = require('prosemirror-utils');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-// Build a command that splits a list item by the current cursor's position.
+// Splits a list item by the current cursor's position.
 // Some examples:
+//
 // - split before item's text:
 //   - before:
 //     1. <cursor>AA
@@ -38,6 +39,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 //     2. AA
 //     3. BB
 //     4. CC
+//
 // - split between item's text:
 //   - before:
 //     1. AA
@@ -48,6 +50,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 //     2. B
 //     3. B
 //     4. CC
+//
 // - split after item's text:
 //   - before:
 //     1. AA
@@ -58,6 +61,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 //     2. BB
 //     3. <cursor>
 //     4. CC
+//
 // - split at item with empty content:
 //   - before:
 //     1. AA
@@ -68,6 +72,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 //     <cursor>
 //     2. BB
 //     3. CC
+//
 function splitListItem(tr, schema) {
   var nodeType = schema.nodes[_NodeNames.LIST_ITEM];
   if (!nodeType) {
@@ -110,7 +115,7 @@ function splitListItem(tr, schema) {
   return tr.split($from.pos, 2, types);
 }
 
-// This splits an item with empty content:
+// Splits an item with empty content:
 //   - before:
 //     1. AA
 //     2. <cursor>

--- a/dist/splitListItem.js.flow
+++ b/dist/splitListItem.js.flow
@@ -1,9 +1,10 @@
 // @flow
 
-import {Fragment, Schema, Slice} from 'prosemirror-model';
+import {Fragment, Schema} from 'prosemirror-model';
+import {TextSelection} from 'prosemirror-state';
 import {Transform, canSplit} from 'prosemirror-transform';
-
-import {LIST_ITEM} from './NodeNames';
+import {LIST_ITEM, ORDERED_LIST, BULLET_LIST, PARAGRAPH} from './NodeNames';
+import {findParentNodeOfType} from 'prosemirror-utils';
 
 // Build a command that splits a non-empty textblock at the top level
 // of a list item by also splitting that list item.
@@ -35,33 +36,33 @@ export default function splitListItem(
     // In an empty block. If this is a nested list, the wrapping
     // list item should be split. Otherwise, bail out and let next
     // command handle lifting.
-    if (
-      $from.depth == 2 ||
-      $from.node(-3).type !== nodeType ||
-      $from.index(-2) != $from.node(-2).childCount - 1
-    ) {
-      return tr;
-    }
+    // if (
+    //   $from.depth == 2 ||
+    //   $from.node(-3).type !== nodeType ||
+    //   $from.index(-2) != $from.node(-2).childCount - 1
+    // ) {
+    //   return tr;
+    // }
 
-    let wrap = Fragment.empty;
-    const keepItem = $from.index(-1) > 0;
-    // Build a fragment containing empty versions of the structure
-    // from the outer list item to the parent node of the cursor
-    for (let d = $from.depth - (keepItem ? 1 : 2); d >= $from.depth - 3; d--) {
-      wrap = Fragment.from($from.node(d).copy(wrap));
-    }
+    // let wrap = Fragment.empty;
+    // const keepItem = $from.index(-1) > 0;
+    // // Build a fragment containing empty versions of the structure
+    // // from the outer list item to the parent node of the cursor
+    // for (let d = $from.depth - (keepItem ? 1 : 2); d >= $from.depth - 3; d--) {
+    //   wrap = Fragment.from($from.node(d).copy(wrap));
+    // }
 
-    // Add a second list item with an empty default start node
-    wrap = wrap.append(Fragment.from(nodeType.createAndFill()));
-    tr = tr.replace(
-      $from.before(keepItem ? null : -1),
-      $from.after(-3),
-      new Slice(wrap, keepItem ? 3 : 2, 2)
-    );
+    // // Add a second list item with an empty default start node
+    // wrap = wrap.append(Fragment.from(nodeType.createAndFill()));
+    // tr = tr.replace(
+    //   $from.before(keepItem ? null : -1),
+    //   $from.after(-3),
+    //   new Slice(wrap, keepItem ? 3 : 2, 2)
+    // );
 
-    const pos = $from.pos + (keepItem ? 3 : 2);
-    tr = tr.setSelection(selection.constructor.near(tr.doc.resolve(pos)));
-    return tr;
+    // const pos = $from.pos + (keepItem ? 3 : 2);
+    // tr = tr.setSelection(selection.constructor.near(tr.doc.resolve(pos)));
+    return insertParagraphAndSplitBlankListItem(tr, schema);
   }
 
   const nextType =
@@ -76,4 +77,67 @@ export default function splitListItem(
   }
 
   return tr.split($from.pos, 2, types);
+}
+
+function insertParagraphAndSplitBlankListItem(
+  tr: Transform,
+  schema: Schema
+): Transform {
+  const listItemType = schema.nodes[LIST_ITEM];
+  const orderedListType = schema.nodes[ORDERED_LIST];
+  const bulletListType = schema.nodes[BULLET_LIST];
+  const paragraphType = schema.nodes[PARAGRAPH];
+  if (!listItemType || !paragraphType) {
+    // Schema does not support the nodes expected.
+    return tr;
+  }
+  const listItemFound = findParentNodeOfType(listItemType)(tr.selection);
+  if (!listItemFound || listItemFound.node.textContent !== '') {
+    // Selection cursor is not inside an empty list item.
+    return tr;
+  }
+
+  const listFound =
+    (orderedListType && findParentNodeOfType(orderedListType)(tr.selection)) ||
+    (bulletListType && findParentNodeOfType(bulletListType)(tr.selection));
+
+  if (!listFound) {
+    // Selection isn't inside an list.
+    return tr;
+  }
+
+  const $listItemPos = tr.doc.resolve(listItemFound.pos);
+  const listItemIndex = $listItemPos.index($listItemPos.depth);
+  if (
+    listFound.node.childCount < 3 ||
+    listItemIndex < 1 ||
+    listItemIndex >= listFound.node.childCount - 1
+  ) {
+    // - The list must have at least three list items
+    // - The cursor must be after the first list item and before the last list
+    //   item.
+    // If both conditions don't match, bails out.
+    return tr;
+  }
+
+  const sliceFrom = listItemFound.pos + listItemFound.node.nodeSize;
+  const sliceTo = listFound.pos + listFound.node.nodeSize - 1;
+  const slicedItems = tr.doc.slice(sliceFrom, sliceTo, false);
+
+  const deleteFrom = listItemFound.pos;
+  const deleteTo = listFound.pos + listFound.node.nodeSize;
+  tr = tr.delete(deleteFrom, deleteTo);
+  const sourceListNode = listFound.node;
+  const listAttrs = {...sourceListNode.attrs};
+  if (orderedListType === sourceListNode.type) {
+    listAttrs.counterReset = 'none';
+  }
+
+  const insertFrom = deleteFrom + 1;
+  const listNode = sourceListNode.type.create(listAttrs, slicedItems.content);
+  tr = tr.insert(insertFrom, listNode);
+  const paragraph = paragraphType.create({}, Fragment.empty);
+  tr = tr.insert(insertFrom, paragraph);
+  tr = tr.setSelection(TextSelection.create(tr.doc, insertFrom));
+  return tr;
 }

--- a/dist/splitListItem.js.flow
+++ b/dist/splitListItem.js.flow
@@ -7,8 +7,9 @@ import {Transform, canSplit} from 'prosemirror-transform';
 import {LIST_ITEM, ORDERED_LIST, BULLET_LIST, PARAGRAPH} from './NodeNames';
 import {findParentNodeOfType} from 'prosemirror-utils';
 
-// Build a command that splits a list item by the current cursor's position.
+// Splits a list item by the current cursor's position.
 // Some examples:
+//
 // - split before item's text:
 //   - before:
 //     1. <cursor>AA
@@ -19,6 +20,7 @@ import {findParentNodeOfType} from 'prosemirror-utils';
 //     2. AA
 //     3. BB
 //     4. CC
+//
 // - split between item's text:
 //   - before:
 //     1. AA
@@ -29,6 +31,7 @@ import {findParentNodeOfType} from 'prosemirror-utils';
 //     2. B
 //     3. B
 //     4. CC
+//
 // - split after item's text:
 //   - before:
 //     1. AA
@@ -39,6 +42,7 @@ import {findParentNodeOfType} from 'prosemirror-utils';
 //     2. BB
 //     3. <cursor>
 //     4. CC
+//
 // - split at item with empty content:
 //   - before:
 //     1. AA
@@ -49,6 +53,7 @@ import {findParentNodeOfType} from 'prosemirror-utils';
 //     <cursor>
 //     2. BB
 //     3. CC
+//
 export default function splitListItem(
   tr: Transform,
   schema: Schema
@@ -92,7 +97,7 @@ export default function splitListItem(
   return tr.split($from.pos, 2, types);
 }
 
-// This splits an item with empty content:
+// Splits an item with empty content:
 //   - before:
 //     1. AA
 //     2. <cursor>

--- a/dist/splitListItem.js.flow
+++ b/dist/splitListItem.js.flow
@@ -164,7 +164,7 @@ function splitEmptyListItem(tr: Transform, schema: Schema): Transform {
   }
 
   // We'll split the list into two lists.
-  // the first liust contains the items before the cursor, and the second
+  // the first list contains the items before the cursor, and the second
   // list contains the items after the cursor and the second list will "follow"
   // the first list by sharing the same counter variable.
   const sliceFrom = listItemFound.pos + listItemFound.node.nodeSize;

--- a/src/OrderedListNodeSpec.js
+++ b/src/OrderedListNodeSpec.js
@@ -9,6 +9,7 @@ import {ATTRIBUTE_INDENT, MIN_INDENT_LEVEL} from './ParagraphNodeSpec';
 import type {NodeSpec} from './Types';
 
 const ATTRIBUTE_COUNTER_RESET = 'data-counter-reset';
+const ATTRIBUTE_FOLLOWING = 'data-following';
 const AUTO_LIST_STYLE_TYPES = ['decimal', 'lower-alpha', 'lower-roman'];
 
 const OrderedListNodeSpec: NodeSpec = {
@@ -16,7 +17,9 @@ const OrderedListNodeSpec: NodeSpec = {
     id: {default: null},
     counterReset: {default: null},
     indent: {default: MIN_INDENT_LEVEL},
+    following: {default: null},
     listStyleType: {default: null},
+    name: {default: null},
     start: {default: 1},
   },
   group: 'block',
@@ -37,22 +40,40 @@ const OrderedListNodeSpec: NodeSpec = {
           ? parseInt(dom.getAttribute(ATTRIBUTE_INDENT), 10)
           : MIN_INDENT_LEVEL;
 
+        const name = dom.getAttribute('name') || undefined;
+
+        const following = dom.getAttribute(ATTRIBUTE_FOLLOWING) || undefined;
+
         return {
           counterReset,
+          following,
           indent,
           listStyleType,
+          name,
           start,
         };
       },
     },
   ],
   toDOM(node: Node) {
-    const {start, indent, listStyleType, counterReset} = node.attrs;
+    const {
+      start,
+      indent,
+      listStyleType,
+      counterReset,
+      following,
+      name,
+    } = node.attrs;
     const attrs: Object = {
       [ATTRIBUTE_INDENT]: indent,
     };
+
     if (counterReset === 'none') {
       attrs[ATTRIBUTE_COUNTER_RESET] = counterReset;
+    }
+
+    if (following) {
+      attrs[ATTRIBUTE_FOLLOWING] = following;
     }
 
     if (listStyleType) {
@@ -61,6 +82,10 @@ const OrderedListNodeSpec: NodeSpec = {
 
     if (start !== 1) {
       attrs.start = start;
+    }
+
+    if (name) {
+      attrs.name = name;
     }
 
     let htmlListStyleType = listStyleType;

--- a/src/consolidateListNodes.js
+++ b/src/consolidateListNodes.js
@@ -14,9 +14,27 @@ type JointInfo = {
   insertAt: number,
 };
 
-// Consolidate list nodes.
-// All adjacent list nodes with the same list type and indent level will be
-// joined into one list node.
+// This function consolidates list nodes among the same "Lists Island".
+//
+// ## Definition of a "Lists Island"
+//   Separate list that are adjacent to each other are grouped as
+//   a "Lists Island".
+//   For example, the following HTML snippets contains two "Lists Island":
+//
+//     <h1>text</h1>
+//     <!-- Lists Island Starts -->
+//     <ul><li>text</li><li>text</li></ul>
+//     <ol><li>text</li><li>text</li></ul>
+//     <!-- Lists Island Ends -->
+//     <p>text</p>
+//     <!-- Lists Island Starts -->
+//     <ul><li>text</li><li>text</li></ul>
+//     <ol><li>text</li><li>text</li></ul>
+//     <!-- Lists Island Ends -->
+//     <p>text</p>
+//
+// List nodes with the same list type and indent level among the same Lists
+// Island will be joined into one list node.
 // Note that this transform may change the current user selection.
 export default function consolidateListNodes(tr: Transform): Transform {
   if (tr.getMeta('dryrun')) {
@@ -44,8 +62,8 @@ export default function consolidateListNodes(tr: Transform): Transform {
 }
 
 /**
- * This ensures that the adjacent ordered lists within the same indent level
- * share the same counter.
+ * This ensures that ordered lists with the same indent level among the same
+ * Lists Island share the same counter.
  *
  * For example, the following three lists:
  *   --------
@@ -78,6 +96,8 @@ function linkOrderedListCounters(tr: Transform): Transform {
     return tr;
   }
 
+  const namedLists = new Set();
+
   let listsBefore = null;
   tr.doc.nodesBetween(from, to, (node, pos, parentNode) => {
     let willTraverseNodeChildren = true;
@@ -86,6 +106,11 @@ function linkOrderedListCounters(tr: Transform): Transform {
       willTraverseNodeChildren = false;
       const indent = node.attrs.indent || 0;
       const start = node.attrs.start || 1;
+      const {name, following} = node.attrs;
+      if (name) {
+        namedLists.add(name);
+      }
+
       if (listsBefore) {
         if (start === 1 && isOrderedListNode(node)) {
           // Look backward until we could find another ordered list node to
@@ -140,13 +165,16 @@ function linkOrderedListCounters(tr: Transform): Transform {
           }
         }
       } else {
-        // Found the first list.
+        // Found the first list for a new Lists Island.
         // ------
         // 1. AAA <- Counter restarts here.
         // 2. BBB
         listsBefore = [];
         if (isOrderedListNode(node)) {
-          tr = setCounterLinked(tr, pos, false);
+          // The list may follow a previous list that is among another Lists
+          // Island. If so, do not reset the list counter.
+          const counterIsLinked = namedLists.has(following);
+          tr = setCounterLinked(tr, pos, counterIsLinked);
         }
       }
       listsBefore.unshift({parentNode, indent, node});

--- a/src/consolidateListNodes.js
+++ b/src/consolidateListNodes.js
@@ -165,7 +165,7 @@ function linkOrderedListCounters(tr: Transform): Transform {
           }
         }
       } else {
-        // Found the first list for a new Lists Island.
+        // Found the first list among a new Lists Island.
         // ------
         // 1. AAA <- Counter restarts here.
         // 2. BBB

--- a/src/splitListItem.js
+++ b/src/splitListItem.js
@@ -1,9 +1,10 @@
 // @flow
 
-import {Fragment, Schema, Slice} from 'prosemirror-model';
+import {Fragment, Schema} from 'prosemirror-model';
+import {TextSelection} from 'prosemirror-state';
 import {Transform, canSplit} from 'prosemirror-transform';
-
-import {LIST_ITEM} from './NodeNames';
+import {LIST_ITEM, ORDERED_LIST, BULLET_LIST, PARAGRAPH} from './NodeNames';
+import {findParentNodeOfType} from 'prosemirror-utils';
 
 // Build a command that splits a non-empty textblock at the top level
 // of a list item by also splitting that list item.
@@ -35,33 +36,33 @@ export default function splitListItem(
     // In an empty block. If this is a nested list, the wrapping
     // list item should be split. Otherwise, bail out and let next
     // command handle lifting.
-    if (
-      $from.depth == 2 ||
-      $from.node(-3).type !== nodeType ||
-      $from.index(-2) != $from.node(-2).childCount - 1
-    ) {
-      return tr;
-    }
+    // if (
+    //   $from.depth == 2 ||
+    //   $from.node(-3).type !== nodeType ||
+    //   $from.index(-2) != $from.node(-2).childCount - 1
+    // ) {
+    //   return tr;
+    // }
 
-    let wrap = Fragment.empty;
-    const keepItem = $from.index(-1) > 0;
-    // Build a fragment containing empty versions of the structure
-    // from the outer list item to the parent node of the cursor
-    for (let d = $from.depth - (keepItem ? 1 : 2); d >= $from.depth - 3; d--) {
-      wrap = Fragment.from($from.node(d).copy(wrap));
-    }
+    // let wrap = Fragment.empty;
+    // const keepItem = $from.index(-1) > 0;
+    // // Build a fragment containing empty versions of the structure
+    // // from the outer list item to the parent node of the cursor
+    // for (let d = $from.depth - (keepItem ? 1 : 2); d >= $from.depth - 3; d--) {
+    //   wrap = Fragment.from($from.node(d).copy(wrap));
+    // }
 
-    // Add a second list item with an empty default start node
-    wrap = wrap.append(Fragment.from(nodeType.createAndFill()));
-    tr = tr.replace(
-      $from.before(keepItem ? null : -1),
-      $from.after(-3),
-      new Slice(wrap, keepItem ? 3 : 2, 2)
-    );
+    // // Add a second list item with an empty default start node
+    // wrap = wrap.append(Fragment.from(nodeType.createAndFill()));
+    // tr = tr.replace(
+    //   $from.before(keepItem ? null : -1),
+    //   $from.after(-3),
+    //   new Slice(wrap, keepItem ? 3 : 2, 2)
+    // );
 
-    const pos = $from.pos + (keepItem ? 3 : 2);
-    tr = tr.setSelection(selection.constructor.near(tr.doc.resolve(pos)));
-    return tr;
+    // const pos = $from.pos + (keepItem ? 3 : 2);
+    // tr = tr.setSelection(selection.constructor.near(tr.doc.resolve(pos)));
+    return insertParagraphAndSplitBlankListItem(tr, schema);
   }
 
   const nextType =
@@ -76,4 +77,67 @@ export default function splitListItem(
   }
 
   return tr.split($from.pos, 2, types);
+}
+
+function insertParagraphAndSplitBlankListItem(
+  tr: Transform,
+  schema: Schema
+): Transform {
+  const listItemType = schema.nodes[LIST_ITEM];
+  const orderedListType = schema.nodes[ORDERED_LIST];
+  const bulletListType = schema.nodes[BULLET_LIST];
+  const paragraphType = schema.nodes[PARAGRAPH];
+  if (!listItemType || !paragraphType) {
+    // Schema does not support the nodes expected.
+    return tr;
+  }
+  const listItemFound = findParentNodeOfType(listItemType)(tr.selection);
+  if (!listItemFound || listItemFound.node.textContent !== '') {
+    // Selection cursor is not inside an empty list item.
+    return tr;
+  }
+
+  const listFound =
+    (orderedListType && findParentNodeOfType(orderedListType)(tr.selection)) ||
+    (bulletListType && findParentNodeOfType(bulletListType)(tr.selection));
+
+  if (!listFound) {
+    // Selection isn't inside an list.
+    return tr;
+  }
+
+  const $listItemPos = tr.doc.resolve(listItemFound.pos);
+  const listItemIndex = $listItemPos.index($listItemPos.depth);
+  if (
+    listFound.node.childCount < 3 ||
+    listItemIndex < 1 ||
+    listItemIndex >= listFound.node.childCount - 1
+  ) {
+    // - The list must have at least three list items
+    // - The cursor must be after the first list item and before the last list
+    //   item.
+    // If both conditions don't match, bails out.
+    return tr;
+  }
+
+  const sliceFrom = listItemFound.pos + listItemFound.node.nodeSize;
+  const sliceTo = listFound.pos + listFound.node.nodeSize - 1;
+  const slicedItems = tr.doc.slice(sliceFrom, sliceTo, false);
+
+  const deleteFrom = listItemFound.pos;
+  const deleteTo = listFound.pos + listFound.node.nodeSize;
+  tr = tr.delete(deleteFrom, deleteTo);
+  const sourceListNode = listFound.node;
+  const listAttrs = {...sourceListNode.attrs};
+  if (orderedListType === sourceListNode.type) {
+    listAttrs.counterReset = 'none';
+  }
+
+  const insertFrom = deleteFrom + 1;
+  const listNode = sourceListNode.type.create(listAttrs, slicedItems.content);
+  tr = tr.insert(insertFrom, listNode);
+  const paragraph = paragraphType.create({}, Fragment.empty);
+  tr = tr.insert(insertFrom, paragraph);
+  tr = tr.setSelection(TextSelection.create(tr.doc, insertFrom));
+  return tr;
 }

--- a/src/splitListItem.js
+++ b/src/splitListItem.js
@@ -7,8 +7,9 @@ import {Transform, canSplit} from 'prosemirror-transform';
 import {LIST_ITEM, ORDERED_LIST, BULLET_LIST, PARAGRAPH} from './NodeNames';
 import {findParentNodeOfType} from 'prosemirror-utils';
 
-// Build a command that splits a list item by the current cursor's position.
+// Splits a list item by the current cursor's position.
 // Some examples:
+//
 // - split before item's text:
 //   - before:
 //     1. <cursor>AA
@@ -19,6 +20,7 @@ import {findParentNodeOfType} from 'prosemirror-utils';
 //     2. AA
 //     3. BB
 //     4. CC
+//
 // - split between item's text:
 //   - before:
 //     1. AA
@@ -29,6 +31,7 @@ import {findParentNodeOfType} from 'prosemirror-utils';
 //     2. B
 //     3. B
 //     4. CC
+//
 // - split after item's text:
 //   - before:
 //     1. AA
@@ -39,6 +42,7 @@ import {findParentNodeOfType} from 'prosemirror-utils';
 //     2. BB
 //     3. <cursor>
 //     4. CC
+//
 // - split at item with empty content:
 //   - before:
 //     1. AA
@@ -49,6 +53,7 @@ import {findParentNodeOfType} from 'prosemirror-utils';
 //     <cursor>
 //     2. BB
 //     3. CC
+//
 export default function splitListItem(
   tr: Transform,
   schema: Schema
@@ -92,7 +97,7 @@ export default function splitListItem(
   return tr.split($from.pos, 2, types);
 }
 
-// This splits an item with empty content:
+// Splits an item with empty content:
 //   - before:
 //     1. AA
 //     2. <cursor>

--- a/src/splitListItem.js
+++ b/src/splitListItem.js
@@ -164,7 +164,7 @@ function splitEmptyListItem(tr: Transform, schema: Schema): Transform {
   }
 
   // We'll split the list into two lists.
-  // the first liust contains the items before the cursor, and the second
+  // the first list contains the items before the cursor, and the second
   // list contains the items after the cursor and the second list will "follow"
   // the first list by sharing the same counter variable.
   const sliceFrom = listItemFound.pos + listItemFound.node.nodeSize;


### PR DESCRIPTION
Due to popular requests from users, we'd like to allow user to split lists without breaking the counter's order.

For now, if user presses the ENTER key at an empty list item between a list, it will split the list and each list resets it own counter.

So this list 

---
![image](https://user-images.githubusercontent.com/1504439/58599027-64f17700-8233-11e9-977e-208ef5d6d6a5.png)
---

becomes two lists that are separate by a new paragraph.

---
![image](https://user-images.githubusercontent.com/1504439/58599066-75095680-8233-11e9-9268-e4238ebd8268.png)
---

With this PR, the split lists that are by the non-list blocks (e.g. paragraph)  can still share the same counter.

---
![image](https://user-images.githubusercontent.com/1504439/58599161-d4676680-8233-11e9-9c75-749efdd39f34.png)
---

so user will be easily to insert block contents between list items
For example, 

---
![image](https://user-images.githubusercontent.com/1504439/58599211-1e504c80-8234-11e9-809c-a844de2b8a4e.png)
---

DEMO
---
![aaa](https://user-images.githubusercontent.com/1504439/58599638-01b51400-8236-11e9-862b-5f22cf544fac.gif)

---

