### PR TITLE
[FIX] Resizing table with merged cells should work as expected.

### DIFF
--- a/dist/TableResizePlugin.js
+++ b/dist/TableResizePlugin.js
@@ -322,7 +322,6 @@ function handleDragEnd(view, event) {
   var tr = view.state.tr;
   for (var row = 0; row < map.height; row++) {
     for (var col = 0; col < widths.length; col++) {
-      // const width = widths[col];
       var mapIndex = row * map.width + col;
       if (row && map.map[mapIndex] == map.map[mapIndex - map.width]) {
         // Rowspanning cell that has already been handled
@@ -337,8 +336,6 @@ function handleDragEnd(view, event) {
       var colwidth = widths.slice(col, col + colspan);
 
       if (colspan > 1) {
-        // The current `colwidth` will be shared with the cells that are
-        // spanned by the current cell.
         col += colspan - 1;
       }
 

--- a/dist/TableResizePlugin.js
+++ b/dist/TableResizePlugin.js
@@ -322,7 +322,7 @@ function handleDragEnd(view, event) {
   var tr = view.state.tr;
   for (var row = 0; row < map.height; row++) {
     for (var col = 0; col < widths.length; col++) {
-      var width = widths[col];
+      // const width = widths[col];
       var mapIndex = row * map.width + col;
       if (row && map.map[mapIndex] == map.map[mapIndex - map.width]) {
         // Rowspanning cell that has already been handled
@@ -333,14 +333,19 @@ function handleDragEnd(view, event) {
       var _table$nodeAt = table.nodeAt(pos),
           attrs = _table$nodeAt.attrs;
 
-      var index = attrs.colspan == 1 ? 0 : col - map.colCount(pos);
+      var colspan = attrs.colspan || 1;
+      var colwidth = widths.slice(col, col + colspan);
 
-      if (attrs.colwidth && attrs.colwidth[index] === width) {
+      if (colspan > 1) {
+        // The current `colwidth` will be shared with the cells that are
+        // spanned by the current cell.
+        col += colspan - 1;
+      }
+
+      if (attrs.colwidth && compareNumbersList(attrs.colwidth, colwidth)) {
         continue;
       }
 
-      var colwidth = attrs.colwidth ? attrs.colwidth.slice() : zeroes(attrs.colspan);
-      colwidth[index] = width;
       tr = tr.setNodeMarkup(start + pos, null, (0, _prosemirrorTables.setAttr)(attrs, 'colwidth', colwidth));
     }
   }
@@ -470,12 +475,6 @@ function updateResizeHandle(view, cellPos, forMarginLeft) {
   }));
 }
 
-function zeroes(n) {
-  var result = new Array(n);
-  result.fill(0);
-  return result;
-}
-
 // Get the decorations that renders the resize handle bars.
 function handleDecorations(state, resizeState) {
   if (!resizeState.cellPos) {
@@ -535,6 +534,16 @@ function batchMouseHandler(handler) {
     view = ev;
     requestAnimationFrame(onMouseEvent);
   };
+}
+
+function compareNumbersList(one, two) {
+  if (one.length !== two.length) {
+    return false;
+  }
+
+  return !one.some(function (value, index) {
+    return two[index] !== value;
+  });
 }
 
 // Plugin that supports table columns resizing.

--- a/dist/TableResizePlugin.js
+++ b/dist/TableResizePlugin.js
@@ -336,6 +336,8 @@ function handleDragEnd(view, event) {
       var colwidth = widths.slice(col, col + colspan);
 
       if (colspan > 1) {
+        // The current cell spans across multiple columns, this forwards to
+        // the next cell for the next iteration.
         col += colspan - 1;
       }
 

--- a/dist/TableResizePlugin.js.flow
+++ b/dist/TableResizePlugin.js.flow
@@ -309,7 +309,6 @@ function handleDragEnd(view: EditorView, event: PointerEvent): void {
   let tr = view.state.tr;
   for (let row = 0; row < map.height; row++) {
     for (let col = 0; col < widths.length; col++) {
-      // const width = widths[col];
       const mapIndex = row * map.width + col;
       if (row && map.map[mapIndex] == map.map[mapIndex - map.width]) {
         // Rowspanning cell that has already been handled
@@ -321,8 +320,6 @@ function handleDragEnd(view: EditorView, event: PointerEvent): void {
       const colwidth = widths.slice(col, col + colspan);
 
       if (colspan > 1) {
-        // The current `colwidth` will be shared with the cells that are
-        // spanned by the current cell.
         col += colspan - 1;
       }
 

--- a/dist/TableResizePlugin.js.flow
+++ b/dist/TableResizePlugin.js.flow
@@ -309,7 +309,7 @@ function handleDragEnd(view: EditorView, event: PointerEvent): void {
   let tr = view.state.tr;
   for (let row = 0; row < map.height; row++) {
     for (let col = 0; col < widths.length; col++) {
-      const width = widths[col];
+      // const width = widths[col];
       const mapIndex = row * map.width + col;
       if (row && map.map[mapIndex] == map.map[mapIndex - map.width]) {
         // Rowspanning cell that has already been handled
@@ -317,16 +317,19 @@ function handleDragEnd(view: EditorView, event: PointerEvent): void {
       }
       const pos = map.map[mapIndex];
       const {attrs} = table.nodeAt(pos);
-      const index = attrs.colspan == 1 ? 0 : col - map.colCount(pos);
+      const colspan = attrs.colspan || 1;
+      const colwidth = widths.slice(col, col + colspan);
 
-      if (attrs.colwidth && attrs.colwidth[index] === width) {
+      if (colspan > 1) {
+        // The current `colwidth` will be shared with the cells that are
+        // spanned by the current cell.
+        col += colspan - 1;
+      }
+
+      if (attrs.colwidth && compareNumbersList(attrs.colwidth, colwidth)) {
         continue;
       }
 
-      const colwidth = attrs.colwidth
-        ? attrs.colwidth.slice()
-        : zeroes(attrs.colspan);
-      colwidth[index] = width;
       tr = tr.setNodeMarkup(
         start + pos,
         null,
@@ -480,12 +483,6 @@ function updateResizeHandle(
   );
 }
 
-function zeroes(n: number): Array<number> {
-  const result = new Array(n);
-  result.fill(0);
-  return result;
-}
-
 // Get the decorations that renders the resize handle bars.
 function handleDecorations(
   state: EditorState,
@@ -553,6 +550,14 @@ function batchMouseHandler(
     view = ev;
     requestAnimationFrame(onMouseEvent);
   };
+}
+
+function compareNumbersList(one: Array<number>, two: Array<number>): boolean {
+  if (one.length !== two.length) {
+    return false;
+  }
+
+  return !one.some((value, index) => two[index] !== value);
 }
 
 // Plugin that supports table columns resizing.

--- a/dist/TableResizePlugin.js.flow
+++ b/dist/TableResizePlugin.js.flow
@@ -320,6 +320,8 @@ function handleDragEnd(view: EditorView, event: PointerEvent): void {
       const colwidth = widths.slice(col, col + colspan);
 
       if (colspan > 1) {
+        // The current cell spans across multiple columns, this forwards to
+        // the next cell for the next iteration.
         col += colspan - 1;
       }
 

--- a/src/TableResizePlugin.js
+++ b/src/TableResizePlugin.js
@@ -309,7 +309,6 @@ function handleDragEnd(view: EditorView, event: PointerEvent): void {
   let tr = view.state.tr;
   for (let row = 0; row < map.height; row++) {
     for (let col = 0; col < widths.length; col++) {
-      // const width = widths[col];
       const mapIndex = row * map.width + col;
       if (row && map.map[mapIndex] == map.map[mapIndex - map.width]) {
         // Rowspanning cell that has already been handled
@@ -321,8 +320,6 @@ function handleDragEnd(view: EditorView, event: PointerEvent): void {
       const colwidth = widths.slice(col, col + colspan);
 
       if (colspan > 1) {
-        // The current `colwidth` will be shared with the cells that are
-        // spanned by the current cell.
         col += colspan - 1;
       }
 

--- a/src/TableResizePlugin.js
+++ b/src/TableResizePlugin.js
@@ -309,7 +309,7 @@ function handleDragEnd(view: EditorView, event: PointerEvent): void {
   let tr = view.state.tr;
   for (let row = 0; row < map.height; row++) {
     for (let col = 0; col < widths.length; col++) {
-      const width = widths[col];
+      // const width = widths[col];
       const mapIndex = row * map.width + col;
       if (row && map.map[mapIndex] == map.map[mapIndex - map.width]) {
         // Rowspanning cell that has already been handled
@@ -317,16 +317,19 @@ function handleDragEnd(view: EditorView, event: PointerEvent): void {
       }
       const pos = map.map[mapIndex];
       const {attrs} = table.nodeAt(pos);
-      const index = attrs.colspan == 1 ? 0 : col - map.colCount(pos);
+      const colspan = attrs.colspan || 1;
+      const colwidth = widths.slice(col, col + colspan);
 
-      if (attrs.colwidth && attrs.colwidth[index] === width) {
+      if (colspan > 1) {
+        // The current `colwidth` will be shared with the cells that are
+        // spanned by the current cell.
+        col += colspan - 1;
+      }
+
+      if (attrs.colwidth && compareNumbersList(attrs.colwidth, colwidth)) {
         continue;
       }
 
-      const colwidth = attrs.colwidth
-        ? attrs.colwidth.slice()
-        : zeroes(attrs.colspan);
-      colwidth[index] = width;
       tr = tr.setNodeMarkup(
         start + pos,
         null,
@@ -480,12 +483,6 @@ function updateResizeHandle(
   );
 }
 
-function zeroes(n: number): Array<number> {
-  const result = new Array(n);
-  result.fill(0);
-  return result;
-}
-
 // Get the decorations that renders the resize handle bars.
 function handleDecorations(
   state: EditorState,
@@ -553,6 +550,14 @@ function batchMouseHandler(
     view = ev;
     requestAnimationFrame(onMouseEvent);
   };
+}
+
+function compareNumbersList(one: Array<number>, two: Array<number>): boolean {
+  if (one.length !== two.length) {
+    return false;
+  }
+
+  return !one.some((value, index) => two[index] !== value);
 }
 
 // Plugin that supports table columns resizing.

--- a/src/TableResizePlugin.js
+++ b/src/TableResizePlugin.js
@@ -320,6 +320,8 @@ function handleDragEnd(view: EditorView, event: PointerEvent): void {
       const colwidth = widths.slice(col, col + colspan);
 
       if (colspan > 1) {
+        // The current cell spans across multiple columns, this forwards to
+        // the next cell for the next iteration.
         col += colspan - 1;
       }
 


### PR DESCRIPTION
## About

After resizing a cell that spans multiple columns, the table's layout will appear broken (e.g. wider or narrower than expected).

## Test Plan
- Test the following snippet https://gist.github.com/hedgerwang/f453d8370b004047cc33bf91929b596f
- Test with url http://localhost:3001/convert.html

| Before | After |
|---|---|
| Resizing a simple table works fine, but resizing a table with merged cells will end up with wrong layout | Works as expected |
|![before](https://user-images.githubusercontent.com/1504439/58723807-d47c7900-838f-11e9-8203-345851110677.gif)|![after](https://user-images.githubusercontent.com/1504439/58723565-3b4d6280-838f-11e9-8139-08a9a968046c.gif)|