### PR TITLE
[FIX]: List counter's style should match its content.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -40,6 +40,7 @@
     "File": false,
     "FileReader": false,
     "HTMLElement": false,
+    "HTMLLIElement": false,
     "HTMLTableElement": false,
     "Image": false,
     "KeyboardEvent": false,

--- a/dist/ListItemNodeSpec.js
+++ b/dist/ListItemNodeSpec.js
@@ -3,11 +3,13 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.ATTRIBUTE_LIST_STYLE_TYPE = undefined;
+
+var _prosemirrorModel = require('prosemirror-model');
 
 var babelPluginFlowReactPropTypes_proptype_NodeSpec = require('./Types').babelPluginFlowReactPropTypes_proptype_NodeSpec || require('prop-types').any;
 
 var ATTRIBUTE_LIST_STYLE_TYPE = exports.ATTRIBUTE_LIST_STYLE_TYPE = 'data-list-style-type';
-var ATTRIBUTE_LIST_STYLE_COLOR = exports.ATTRIBUTE_LIST_STYLE_COLOR = 'data-list-style-color';
 
 var ALIGN_PATTERN = /(left|right|center|justify)/;
 
@@ -21,41 +23,33 @@ function getAttrs(dom) {
   if (align) {
     attrs.align = align;
   }
-
-  var color = dom.getAttribute(ATTRIBUTE_LIST_STYLE_COLOR);
-  if (color) {
-    attrs.color = color;
-  }
-
   return attrs;
 }
 
-// https://bitbucket.org/atlassian/atlaskit/src/34facee3f461/packages/editor-core/src/schema/nodes/?at=master
 var ListItemNodeSpec = {
   attrs: {
-    align: { default: null },
-    color: { default: null },
-    id: { default: null },
-    style: { default: null }
+    align: { default: null }
   },
 
-  // NOTE that do not support nested lists `'paragraph block*'` because of
-  // the complexity of dealing with indentation.
+  // NOTE:
+  // This spec does not support nested lists (e.g. `'paragraph block*'`)
+  // as content because of the complexity of dealing with indentation
+  // (context: https://github.com/ProseMirror/prosemirror/issues/92).
   content: 'paragraph',
 
   parseDOM: [{ tag: 'li', getAttrs: getAttrs }],
 
+  // NOTE:
+  // This method only defines the minimum HTML attributes needed when the node
+  // is serialized to HTML string. Usually this is called when user copies
+  // the node to clipboard.
+  // The actual DOM rendering logic is defined at `src/ui/ListItemNodeView.js`.
   toDOM: function toDOM(node) {
     var attrs = {};
-    var _node$attrs = node.attrs,
-        align = _node$attrs.align,
-        color = _node$attrs.color;
+    var align = node.attrs.align;
 
     if (align) {
       attrs['data-align'] = align;
-    }
-    if (color) {
-      attrs.style = '--czi-list-style-color: ' + color;
     }
     return ['li', attrs, 0];
   }

--- a/dist/ListItemNodeSpec.js.flow
+++ b/dist/ListItemNodeSpec.js.flow
@@ -1,9 +1,10 @@
 // @flow
 
+import {Node} from 'prosemirror-model';
+
 import type {NodeSpec} from './Types';
 
 export const ATTRIBUTE_LIST_STYLE_TYPE = 'data-list-style-type';
-export const ATTRIBUTE_LIST_STYLE_COLOR = 'data-list-style-color';
 
 const ALIGN_PATTERN = /(left|right|center|justify)/;
 
@@ -16,38 +17,32 @@ function getAttrs(dom: HTMLElement) {
   if (align) {
     attrs.align = align;
   }
-
-  const color = dom.getAttribute(ATTRIBUTE_LIST_STYLE_COLOR);
-  if (color) {
-    attrs.color = color;
-  }
-
   return attrs;
 }
 
-// https://bitbucket.org/atlassian/atlaskit/src/34facee3f461/packages/editor-core/src/schema/nodes/?at=master
 const ListItemNodeSpec: NodeSpec = {
   attrs: {
     align: {default: null},
-    color: {default: null},
-    id: {default: null},
-    style: {default: null},
   },
 
-  // NOTE that do not support nested lists `'paragraph block*'` because of
-  // the complexity of dealing with indentation.
+  // NOTE:
+  // This spec does not support nested lists (e.g. `'paragraph block*'`)
+  // as content because of the complexity of dealing with indentation
+  // (context: https://github.com/ProseMirror/prosemirror/issues/92).
   content: 'paragraph',
 
   parseDOM: [{tag: 'li', getAttrs}],
 
-  toDOM(node) {
+  // NOTE:
+  // This method only defines the minimum HTML attributes needed when the node
+  // is serialized to HTML string. Usually this is called when user copies
+  // the node to clipboard.
+  // The actual DOM rendering logic is defined at `src/ui/ListItemNodeView.js`.
+  toDOM(node: Node): Array<any> {
     const attrs = {};
-    const {align, color} = node.attrs;
+    const {align} = node.attrs;
     if (align) {
       attrs['data-align'] = align;
-    }
-    if (color) {
-      attrs.style = `--czi-list-style-color: ${color}`;
     }
     return ['li', attrs, 0];
   },

--- a/dist/patchListElements.js
+++ b/dist/patchListElements.js
@@ -20,10 +20,6 @@ var _ParagraphNodeSpec = require('./ParagraphNodeSpec');
 
 var _patchStyleElements = require('./patchStyleElements');
 
-var _toCSSColor = require('./ui/toCSSColor');
-
-var _toCSSColor2 = _interopRequireDefault(_toCSSColor);
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function patchListElements(doc) {
@@ -31,6 +27,8 @@ function patchListElements(doc) {
 }
 
 // This assumes that every 36pt maps to one indent level.
+
+
 var CHAR_BULLET = '\u25CF';
 var CHAR_CIRCLE = '\u25CB';
 var CHAR_SQUARE = '\u25A0';
@@ -80,16 +78,6 @@ function patchListElementsElement(listElement) {
 
     if (ml !== marginLeft) {
       marginLeft = null;
-    }
-
-    var firstElementChild = listItemElement.firstElementChild,
-        lastElementChild = listItemElement.lastElementChild;
-
-    if (firstElementChild && firstElementChild === lastElementChild) {
-      // If <li /> has only only one child with the same text color, assume
-      var el = firstElementChild;
-      var color = el.style ? el.style.color : null;
-      color && listItemElement.setAttribute(_ListItemNodeSpec.ATTRIBUTE_LIST_STYLE_COLOR, (0, _toCSSColor2.default)(color));
     }
   });
 

--- a/dist/patchListElements.js.flow
+++ b/dist/patchListElements.js.flow
@@ -1,16 +1,12 @@
 // @flow
 
-import {
-  ATTRIBUTE_LIST_STYLE_COLOR,
-  ATTRIBUTE_LIST_STYLE_TYPE,
-} from './ListItemNodeSpec';
+import {ATTRIBUTE_LIST_STYLE_TYPE} from './ListItemNodeSpec';
 import {
   ATTRIBUTE_INDENT,
   EMPTY_CSS_VALUE,
   convertMarginLeftToIndentValue,
 } from './ParagraphNodeSpec';
 import {ATTRIBUTE_CSS_BEFORE_CONTENT} from './patchStyleElements';
-import toCSSColor from './ui/toCSSColor';
 
 export default function patchListElements(doc: Document): void {
   Array.from(doc.querySelectorAll('ol, ul')).forEach(patchListElementsElement);
@@ -67,19 +63,6 @@ function patchListElementsElement(listElement: HTMLElement): void {
 
     if (ml !== marginLeft) {
       marginLeft = null;
-    }
-
-    const {firstElementChild, lastElementChild} = listItemElement;
-    if (firstElementChild && firstElementChild === lastElementChild) {
-      // If <li /> has only only one child with the same text color, assume
-      // that text color will be used for list style type, too.
-      const el: any = firstElementChild;
-      const color = el.style ? el.style.color : null;
-      color &&
-        listItemElement.setAttribute(
-          ATTRIBUTE_LIST_STYLE_COLOR,
-          toCSSColor(color)
-        );
     }
   });
 

--- a/dist/ui/Editor.js
+++ b/dist/ui/Editor.js
@@ -99,6 +99,10 @@ var _ImageNodeView = require('./ImageNodeView');
 
 var _ImageNodeView2 = _interopRequireDefault(_ImageNodeView);
 
+var _ListItemNodeView = require('./ListItemNodeView');
+
+var _ListItemNodeView2 = _interopRequireDefault(_ListItemNodeView);
+
 var _MathNodeView = require('./MathNodeView');
 
 var _MathNodeView2 = _interopRequireDefault(_MathNodeView);
@@ -151,7 +155,7 @@ window.CZIProseMirror = {
 var AUTO_FOCUS_DELAY = 350;
 
 // Default custom node views.
-var DEFAULT_NODE_VIEWS = exports.DEFAULT_NODE_VIEWS = (0, _freeze2.default)((_Object$freeze2 = {}, (0, _defineProperty3.default)(_Object$freeze2, _NodeNames.IMAGE, _ImageNodeView2.default), (0, _defineProperty3.default)(_Object$freeze2, _NodeNames.MATH, _MathNodeView2.default), (0, _defineProperty3.default)(_Object$freeze2, _NodeNames.BOOKMARK, _BookmarkNodeView2.default), _Object$freeze2));
+var DEFAULT_NODE_VIEWS = exports.DEFAULT_NODE_VIEWS = (0, _freeze2.default)((_Object$freeze2 = {}, (0, _defineProperty3.default)(_Object$freeze2, _NodeNames.IMAGE, _ImageNodeView2.default), (0, _defineProperty3.default)(_Object$freeze2, _NodeNames.MATH, _MathNodeView2.default), (0, _defineProperty3.default)(_Object$freeze2, _NodeNames.BOOKMARK, _BookmarkNodeView2.default), (0, _defineProperty3.default)(_Object$freeze2, _NodeNames.LIST_ITEM, _ListItemNodeView2.default), _Object$freeze2));
 
 var EDITOR_EMPTY_STATE = (0, _freeze2.default)((0, _createEmptyEditorState2.default)());
 

--- a/dist/ui/Editor.js.flow
+++ b/dist/ui/Editor.js.flow
@@ -17,7 +17,7 @@ import {
   registeryKeys,
   releaseEditorView,
 } from '../CZIProseMirror';
-import {BOOKMARK, IMAGE, MATH} from '../NodeNames';
+import {BOOKMARK, IMAGE, LIST_ITEM, MATH} from '../NodeNames';
 import WebFontLoader from '../WebFontLoader';
 import createEmptyEditorState from '../createEmptyEditorState';
 import normalizeHTML from '../normalizeHTML';
@@ -25,6 +25,7 @@ import BookmarkNodeView from './BookmarkNodeView';
 import CustomEditorView from './CustomEditorView';
 import CustomNodeView from './CustomNodeView';
 import ImageNodeView from './ImageNodeView';
+import ListItemNodeView from './ListItemNodeView';
 import MathNodeView from './MathNodeView';
 import handleEditorDrop from './handleEditorDrop';
 import handleEditorKeyDown from './handleEditorKeyDown';
@@ -65,6 +66,7 @@ export const DEFAULT_NODE_VIEWS = Object.freeze({
   [IMAGE]: ImageNodeView,
   [MATH]: MathNodeView,
   [BOOKMARK]: BookmarkNodeView,
+  [LIST_ITEM]: ListItemNodeView,
 });
 
 const EDITOR_EMPTY_STATE = Object.freeze(createEmptyEditorState());

--- a/dist/ui/ListItemNodeView.js
+++ b/dist/ui/ListItemNodeView.js
@@ -1,0 +1,114 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _classCallCheck2 = require('babel-runtime/helpers/classCallCheck');
+
+var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
+
+var _createClass2 = require('babel-runtime/helpers/createClass');
+
+var _createClass3 = _interopRequireDefault(_createClass2);
+
+var _prosemirrorModel = require('prosemirror-model');
+
+var _prosemirrorView = require('prosemirror-view');
+
+var _MarkNames = require('../MarkNames');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+// This implements the `NodeView` interface
+// https://prosemirror.net/docs/ref/#view.NodeView
+var ListItemNodeView = function () {
+
+  // This implements the `NodeView` interface.
+  // The DOM node that should hold the node's content.
+  function ListItemNodeView(node, editorView, getPos, decorations) {
+    (0, _classCallCheck3.default)(this, ListItemNodeView);
+
+    var dom = document.createElement('li');
+    this.dom = dom;
+    this.contentDOM = dom;
+    this._updateDOM(node);
+  }
+
+  // This implements the `NodeView` interface.
+
+  // This implements the `NodeView` interface
+  // The outer DOM node that represents the list item element.
+
+
+  (0, _createClass3.default)(ListItemNodeView, [{
+    key: 'update',
+    value: function update(node, decorations) {
+      return this._updateDOM(node);
+    }
+  }, {
+    key: '_updateDOM',
+    value: function _updateDOM(node) {
+      if (this._nodeUpdated === node) {
+        return false;
+      }
+
+      this._nodeUpdated = node;
+
+      var dom = this.dom;
+      // According to `ListItemNodeSpec`, a valid list item has the following
+      // structure: `li > paragraph > text`.
+      var paragraph = node.firstChild;
+      var initialContent = paragraph ? paragraph.firstChild : null;
+
+      // This resolves the styles for the counter by examines the marks for the
+      // first text node of the list item.
+      var marks = initialContent && initialContent.isText && initialContent.textContent ? initialContent.marks : null;
+
+      var cssColor = void 0;
+      var cssFontSize = void 0;
+      var cssText = '';
+      if (Array.isArray(marks)) {
+        marks.forEach(function (mark) {
+          var attrs = mark.attrs,
+              type = mark.type;
+
+          switch (type.name) {
+            case _MarkNames.MARK_TEXT_COLOR:
+              cssColor = attrs.color;
+              break;
+            case _MarkNames.MARK_FONT_SIZE:
+              cssFontSize = attrs.pt;
+              break;
+          }
+        });
+      }
+
+      // The counter of the list item is a pseudo-element that uses
+      // the CSS variables (e.g `--czi-list-style-color`) for styling.
+      // This defines the CSS variables scoped for the pseudo-element.
+      // See `src/ui/czi-list.css` for more details.
+      if (cssColor) {
+        cssText += '--czi-list-style-color: ' + cssColor + ';';
+      }
+
+      if (cssFontSize) {
+        cssText += '--czi-list-style-font-size: ' + cssFontSize + 'pt;';
+      }
+
+      dom.style.cssText = cssText;
+
+      var align = node.attrs.align;
+
+      if (align) {
+        dom.setAttribute('data-align', align);
+      } else {
+        dom.removeAttribute('data-align');
+      }
+      return true;
+    }
+  }]);
+  return ListItemNodeView;
+}();
+
+exports.default = ListItemNodeView;

--- a/dist/ui/ListItemNodeView.js.flow
+++ b/dist/ui/ListItemNodeView.js.flow
@@ -1,0 +1,98 @@
+// @flow
+
+import {Node} from 'prosemirror-model';
+import {Decoration, EditorView} from 'prosemirror-view';
+import {MARK_TEXT_COLOR, MARK_FONT_SIZE} from '../MarkNames';
+
+// This implements the `NodeView` interface
+// https://prosemirror.net/docs/ref/#view.NodeView
+class ListItemNodeView {
+  // This implements the `NodeView` interface
+  // The outer DOM node that represents the list item element.
+  dom: HTMLLIElement;
+
+  // This implements the `NodeView` interface.
+  // The DOM node that should hold the node's content.
+  contentDOM: HTMLLIElement;
+
+  _nodeUpdated: ?Node;
+
+  constructor(
+    node: Node,
+    editorView: EditorView,
+    getPos: () => number,
+    decorations: Array<Decoration>
+  ) {
+    const dom = document.createElement('li');
+    this.dom = dom;
+    this.contentDOM = dom;
+    this._updateDOM(node);
+  }
+
+  // This implements the `NodeView` interface.
+  update(node: Node, decorations: Array<Decoration>): boolean {
+    return this._updateDOM(node);
+  }
+
+  _updateDOM(node: Node): boolean {
+    if (this._nodeUpdated === node) {
+      return false;
+    }
+
+    this._nodeUpdated = node;
+
+    const dom = this.dom;
+    // According to `ListItemNodeSpec`, a valid list item has the following
+    // structure: `li > paragraph > text`.
+    const paragraph = node.firstChild;
+    const initialContent = paragraph ? paragraph.firstChild : null;
+
+    // This resolves the styles for the counter by examines the marks for the
+    // first text node of the list item.
+    const marks =
+      initialContent && initialContent.isText && initialContent.textContent
+        ? initialContent.marks
+        : null;
+
+    let cssColor;
+    let cssFontSize;
+    let cssText = '';
+    if (Array.isArray(marks)) {
+      marks.forEach(mark => {
+        const {attrs, type} = mark;
+        switch (type.name) {
+          case MARK_TEXT_COLOR:
+            cssColor = attrs.color;
+            break;
+          case MARK_FONT_SIZE:
+            cssFontSize = attrs.pt;
+            break;
+        }
+      });
+    }
+
+    // The counter of the list item is a pseudo-element that uses
+    // the CSS variables (e.g `--czi-list-style-color`) for styling.
+    // This defines the CSS variables scoped for the pseudo-element.
+    // See `src/ui/czi-list.css` for more details.
+    if (cssColor) {
+      cssText += `--czi-list-style-color: ${cssColor};`;
+    }
+
+    if (cssFontSize) {
+      cssText += `--czi-list-style-font-size: ${cssFontSize}pt;`;
+    }
+
+    dom.style.cssText = cssText;
+
+    const {align} = node.attrs;
+    if (align) {
+      dom.setAttribute('data-align', align);
+    } else {
+      dom.removeAttribute('data-align');
+    }
+    return true;
+  }
+}
+
+export default ListItemNodeView;

--- a/dist/ui/czi-bullet-list.css
+++ b/dist/ui/czi-bullet-list.css
@@ -1,8 +1,6 @@
 .ProseMirror ul li::before {
   /* Default bullet style to "disc" */
   content: '\2022\2009';
-  font-size: 1.85em;
-  line-height: 55%;
 }
 
 .ProseMirror ul[type='square'] li::before {
@@ -11,6 +9,5 @@
 
 .ProseMirror ul[type='circle'] li::before {
   content: '\25cb\2009';
-  font-size: 1.15em;
-  line-height: 120%;
+  transform: scale(0.6);
 }

--- a/dist/ui/czi-list.css
+++ b/dist/ui/czi-list.css
@@ -23,6 +23,7 @@
 .ProseMirror li {
   --czi-list-font-size: 0.95em;
   --czi-list-style-color: initial;
+
   display: flex;
   list-style-type: none;
   margin: 0;

--- a/dist/ui/czi-list.css
+++ b/dist/ui/czi-list.css
@@ -13,6 +13,7 @@
    * https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
    */
   column-span: all;
+  counter-reset: none;
   display: flow-root;
   list-style-type: none;
   margin: 0;
@@ -20,6 +21,8 @@
 }
 
 .ProseMirror li {
+  --czi-list-font-size: 0.95em;
+  --czi-list-style-color: initial;
   display: flex;
   list-style-type: none;
   margin: 0;
@@ -41,7 +44,8 @@
   color: var(--czi-list-style-color);
   content: '';
   display: block;
-  font-size: 0.95em;
+  font-size: var(--czi-list-style-font-size);
+  line-height: 120%;
   position: relative;
   text-align: right;
   top: 0.1em;

--- a/src/ListItemNodeSpec.js
+++ b/src/ListItemNodeSpec.js
@@ -1,9 +1,10 @@
 // @flow
 
+import {Node} from 'prosemirror-model';
+
 import type {NodeSpec} from './Types';
 
 export const ATTRIBUTE_LIST_STYLE_TYPE = 'data-list-style-type';
-export const ATTRIBUTE_LIST_STYLE_COLOR = 'data-list-style-color';
 
 const ALIGN_PATTERN = /(left|right|center|justify)/;
 
@@ -16,38 +17,32 @@ function getAttrs(dom: HTMLElement) {
   if (align) {
     attrs.align = align;
   }
-
-  const color = dom.getAttribute(ATTRIBUTE_LIST_STYLE_COLOR);
-  if (color) {
-    attrs.color = color;
-  }
-
   return attrs;
 }
 
-// https://bitbucket.org/atlassian/atlaskit/src/34facee3f461/packages/editor-core/src/schema/nodes/?at=master
 const ListItemNodeSpec: NodeSpec = {
   attrs: {
     align: {default: null},
-    color: {default: null},
-    id: {default: null},
-    style: {default: null},
   },
 
-  // NOTE that do not support nested lists `'paragraph block*'` because of
-  // the complexity of dealing with indentation.
+  // NOTE:
+  // This spec does not support nested lists (e.g. `'paragraph block*'`)
+  // as content because of the complexity of dealing with indentation
+  // (context: https://github.com/ProseMirror/prosemirror/issues/92).
   content: 'paragraph',
 
   parseDOM: [{tag: 'li', getAttrs}],
 
-  toDOM(node) {
+  // NOTE:
+  // This method only defines the minimum HTML attributes needed when the node
+  // is serialized to HTML string. Usually this is called when user copies
+  // the node to clipboard.
+  // The actual DOM rendering logic is defined at `src/ui/ListItemNodeView.js`.
+  toDOM(node: Node): Array<any> {
     const attrs = {};
-    const {align, color} = node.attrs;
+    const {align} = node.attrs;
     if (align) {
       attrs['data-align'] = align;
-    }
-    if (color) {
-      attrs.style = `--czi-list-style-color: ${color}`;
     }
     return ['li', attrs, 0];
   },

--- a/src/patchListElements.js
+++ b/src/patchListElements.js
@@ -1,16 +1,12 @@
 // @flow
 
-import {
-  ATTRIBUTE_LIST_STYLE_COLOR,
-  ATTRIBUTE_LIST_STYLE_TYPE,
-} from './ListItemNodeSpec';
+import {ATTRIBUTE_LIST_STYLE_TYPE} from './ListItemNodeSpec';
 import {
   ATTRIBUTE_INDENT,
   EMPTY_CSS_VALUE,
   convertMarginLeftToIndentValue,
 } from './ParagraphNodeSpec';
 import {ATTRIBUTE_CSS_BEFORE_CONTENT} from './patchStyleElements';
-import toCSSColor from './ui/toCSSColor';
 
 export default function patchListElements(doc: Document): void {
   Array.from(doc.querySelectorAll('ol, ul')).forEach(patchListElementsElement);
@@ -67,19 +63,6 @@ function patchListElementsElement(listElement: HTMLElement): void {
 
     if (ml !== marginLeft) {
       marginLeft = null;
-    }
-
-    const {firstElementChild, lastElementChild} = listItemElement;
-    if (firstElementChild && firstElementChild === lastElementChild) {
-      // If <li /> has only only one child with the same text color, assume
-      // that text color will be used for list style type, too.
-      const el: any = firstElementChild;
-      const color = el.style ? el.style.color : null;
-      color &&
-        listItemElement.setAttribute(
-          ATTRIBUTE_LIST_STYLE_COLOR,
-          toCSSColor(color)
-        );
     }
   });
 

--- a/src/ui/Editor.js
+++ b/src/ui/Editor.js
@@ -17,7 +17,7 @@ import {
   registeryKeys,
   releaseEditorView,
 } from '../CZIProseMirror';
-import {BOOKMARK, IMAGE, MATH} from '../NodeNames';
+import {BOOKMARK, IMAGE, LIST_ITEM, MATH} from '../NodeNames';
 import WebFontLoader from '../WebFontLoader';
 import createEmptyEditorState from '../createEmptyEditorState';
 import normalizeHTML from '../normalizeHTML';
@@ -25,6 +25,7 @@ import BookmarkNodeView from './BookmarkNodeView';
 import CustomEditorView from './CustomEditorView';
 import CustomNodeView from './CustomNodeView';
 import ImageNodeView from './ImageNodeView';
+import ListItemNodeView from './ListItemNodeView';
 import MathNodeView from './MathNodeView';
 import handleEditorDrop from './handleEditorDrop';
 import handleEditorKeyDown from './handleEditorKeyDown';
@@ -65,6 +66,7 @@ export const DEFAULT_NODE_VIEWS = Object.freeze({
   [IMAGE]: ImageNodeView,
   [MATH]: MathNodeView,
   [BOOKMARK]: BookmarkNodeView,
+  [LIST_ITEM]: ListItemNodeView,
 });
 
 const EDITOR_EMPTY_STATE = Object.freeze(createEmptyEditorState());

--- a/src/ui/ListItemNodeView.js
+++ b/src/ui/ListItemNodeView.js
@@ -1,0 +1,98 @@
+// @flow
+
+import {Node} from 'prosemirror-model';
+import {Decoration, EditorView} from 'prosemirror-view';
+import {MARK_TEXT_COLOR, MARK_FONT_SIZE} from '../MarkNames';
+
+// This implements the `NodeView` interface
+// https://prosemirror.net/docs/ref/#view.NodeView
+class ListItemNodeView {
+  // This implements the `NodeView` interface
+  // The outer DOM node that represents the list item element.
+  dom: HTMLLIElement;
+
+  // This implements the `NodeView` interface.
+  // The DOM node that should hold the node's content.
+  contentDOM: HTMLLIElement;
+
+  _nodeUpdated: ?Node;
+
+  constructor(
+    node: Node,
+    editorView: EditorView,
+    getPos: () => number,
+    decorations: Array<Decoration>
+  ) {
+    const dom = document.createElement('li');
+    this.dom = dom;
+    this.contentDOM = dom;
+    this._updateDOM(node);
+  }
+
+  // This implements the `NodeView` interface.
+  update(node: Node, decorations: Array<Decoration>): boolean {
+    return this._updateDOM(node);
+  }
+
+  _updateDOM(node: Node): boolean {
+    if (this._nodeUpdated === node) {
+      return false;
+    }
+
+    this._nodeUpdated = node;
+
+    const dom = this.dom;
+    // According to `ListItemNodeSpec`, a valid list item has the following
+    // structure: `li > paragraph > text`.
+    const paragraph = node.firstChild;
+    const initialContent = paragraph ? paragraph.firstChild : null;
+
+    // This resolves the styles for the counter by examines the marks for the
+    // first text node of the list item.
+    const marks =
+      initialContent && initialContent.isText && initialContent.textContent
+        ? initialContent.marks
+        : null;
+
+    let cssColor;
+    let cssFontSize;
+    let cssText = '';
+    if (Array.isArray(marks)) {
+      marks.forEach(mark => {
+        const {attrs, type} = mark;
+        switch (type.name) {
+          case MARK_TEXT_COLOR:
+            cssColor = attrs.color;
+            break;
+          case MARK_FONT_SIZE:
+            cssFontSize = attrs.pt;
+            break;
+        }
+      });
+    }
+
+    // The counter of the list item is a pseudo-element that uses
+    // the CSS variables (e.g `--czi-list-style-color`) for styling.
+    // This defines the CSS variables scoped for the pseudo-element.
+    // See `src/ui/czi-list.css` for more details.
+    if (cssColor) {
+      cssText += `--czi-list-style-color: ${cssColor};`;
+    }
+
+    if (cssFontSize) {
+      cssText += `--czi-list-style-font-size: ${cssFontSize}pt;`;
+    }
+
+    dom.style.cssText = cssText;
+
+    const {align} = node.attrs;
+    if (align) {
+      dom.setAttribute('data-align', align);
+    } else {
+      dom.removeAttribute('data-align');
+    }
+    return true;
+  }
+}
+
+export default ListItemNodeView;

--- a/src/ui/czi-bullet-list.css
+++ b/src/ui/czi-bullet-list.css
@@ -1,8 +1,6 @@
 .ProseMirror ul li::before {
   /* Default bullet style to "disc" */
   content: '\2022\2009';
-  font-size: 1.85em;
-  line-height: 55%;
 }
 
 .ProseMirror ul[type='square'] li::before {
@@ -11,6 +9,5 @@
 
 .ProseMirror ul[type='circle'] li::before {
   content: '\25cb\2009';
-  font-size: 1.15em;
-  line-height: 120%;
+  transform: scale(0.6);
 }

--- a/src/ui/czi-list.css
+++ b/src/ui/czi-list.css
@@ -13,6 +13,7 @@
    * https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
    */
   column-span: all;
+  counter-reset: none;
   display: flow-root;
   list-style-type: none;
   margin: 0;
@@ -20,6 +21,9 @@
 }
 
 .ProseMirror li {
+  --czi-list-font-size: 0.95em;
+  --czi-list-style-color: initial;
+
   display: flex;
   list-style-type: none;
   margin: 0;
@@ -41,7 +45,8 @@
   color: var(--czi-list-style-color);
   content: '';
   display: block;
-  font-size: 0.95em;
+  font-size: var(--czi-list-style-font-size);
+  line-height: 120%;
   position: relative;
   text-align: right;
   top: 0.1em;


### PR DESCRIPTION
# Summary

List item's counter should use the same style (e.g. color and font size) as its content.

| Before | After |
|---|---|
| Counter does not use the same style as its content | Counter uses the same style |
| ![image](https://user-images.githubusercontent.com/1504439/58735765-554b6d00-83b0-11e9-986c-61d5d8abb616.png)|![image](https://user-images.githubusercontent.com/1504439/58735779-62685c00-83b0-11e9-8619-b69254f97a7d.png)|


# DEMO
![ccc](https://user-images.githubusercontent.com/1504439/58735933-f6d2be80-83b0-11e9-888c-41e4172dc633.gif)





