### PR TITLE
[EASY]: Fix table border styles in print mode.

### DIFF
--- a/dist/ui/czi-table.css
+++ b/dist/ui/czi-table.css
@@ -7,22 +7,19 @@
 }
 
 .ProseMirror table {
-  border-collapse: initial;
+  border-collapse: collapse;
   border-spacing: 0;
-  border: 1px solid var(--czi-table-border-color);
-  border-width: 0 thin thin 0;
+  border: thin solid var(--czi-table-border-color);
   table-layout: fixed;
   width: 100%;
   margin: 0;
   overflow: hidden;
-  page-break-inside: avoid;
 }
 
 .ProseMirror td,
 .ProseMirror th {
   background-color: #fff;
-  border: 1px solid var(--czi-table-border-color);
-  border-width: thin 0 0 thin;
+  border: thin solid var(--czi-table-border-color);
   box-sizing: border-box;
   min-width: 1em;
   padding: 8px;

--- a/src/ui/czi-table.css
+++ b/src/ui/czi-table.css
@@ -7,22 +7,19 @@
 }
 
 .ProseMirror table {
-  border-collapse: initial;
+  border-collapse: collapse;
   border-spacing: 0;
-  border: 1px solid var(--czi-table-border-color);
-  border-width: 0 thin thin 0;
+  border: thin solid var(--czi-table-border-color);
   table-layout: fixed;
   width: 100%;
   margin: 0;
   overflow: hidden;
-  page-break-inside: avoid;
 }
 
 .ProseMirror td,
 .ProseMirror th {
   background-color: #fff;
-  border: 1px solid var(--czi-table-border-color);
-  border-width: thin 0 0 thin;
+  border: thin solid var(--czi-table-border-color);
   box-sizing: border-box;
   min-width: 1em;
   padding: 8px;


### PR DESCRIPTION
## Before

---
[before.pdf](https://github.com/chanzuckerberg/czi-prosemirror/files/3254504/before.pdf)
---
table cell with merged rows might miss its border.
![image](https://user-images.githubusercontent.com/1504439/58913895-17ad5380-86d2-11e9-846c-502401f3020b.png)
---

## After

---
[after.pdf](https://github.com/chanzuckerberg/czi-prosemirror/files/3254506/after.pdf)
---
![image](https://user-images.githubusercontent.com/1504439/58913939-2b58ba00-86d2-11e9-82e9-ccca421d232d.png)
---


